### PR TITLE
feat: streamable HTTP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Keep the build context small and reproducible: deps and build output are
+# produced inside the image, never copied from the host.
+node_modules
+dist
+coverage
+
+# VCS / editor / CI
+.git
+.gitignore
+.github
+.vscode
+.idea
+
+# Local dev + secrets — must never leak into an image layer.
+.env
+.env.*
+settings.json
+*.local.json
+.claude
+
+# Docs / meta not needed at runtime
+*.md
+!README.md
+
+# OS cruft
+.DS_Store
+Thumbs.db

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,4 +1,4 @@
-name: Build and push Docker image to GHCR
+name: Build and push Docker image
 
 on:
   release:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing git tag / version to build and push (e.g. v2.1.0)'
+        description: 'Image tag to build and push (e.g. v2.1.0)'
         required: true
 
 jobs:
@@ -23,8 +23,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v5
-        with:
-          ref: ${{ steps.ctx.outputs.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -17,10 +17,6 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Resolve version
-        id: ctx
-        run: echo "ref=${{ inputs.tag || github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
-
       - name: Checkout code
         uses: actions/checkout@v5
 
@@ -43,11 +39,13 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{major}},value=${{ steps.ctx.outputs.ref }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.ctx.outputs.ref }}
-            type=semver,pattern={{version}},value=${{ steps.ctx.outputs.ref }}
+            type=semver,pattern={{major}},value=${{ env.TAG }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.TAG }}
+            type=semver,pattern={{version}},value=${{ env.TAG }}
           flavor: |
             latest=${{ github.event_name == 'release' && 'auto' || 'false' }}
+        env:
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
 
       - name: Build and push image
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,62 @@
+name: Build and push Docker image to GHCR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing git tag / version to build and push (e.g. v2.1.0)'
+        required: true
+
+jobs:
+  docker-release:
+    name: Build and push Docker image to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Resolve version
+        id: ctx
+        run: echo "ref=${{ inputs.tag || github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.ctx.outputs.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.ctx.outputs.ref }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.ctx.outputs.ref }}
+          flavor: |
+            latest=${{ github.event_name == 'release' && 'auto' || 'false' }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -43,8 +43,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.ctx.outputs.ref }}
+            type=semver,pattern={{major}},value=${{ steps.ctx.outputs.ref }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.ctx.outputs.ref }}
+            type=semver,pattern={{version}},value=${{ steps.ctx.outputs.ref }}
           flavor: |
             latest=${{ github.event_name == 'release' && 'auto' || 'false' }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ ENV PNPM_HOME=/pnpm
 ENV PATH=$PNPM_HOME:$PATH
 RUN corepack enable
 
+ENV NAVIDROME_CONFIG_PATH=/config/settings.json
+VOLUME ["/config"]
+
 COPY package.json pnpm-lock.yaml ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --prod --frozen-lockfile --ignore-scripts
@@ -37,13 +40,6 @@ COPY --from=build /app/dist ./dist
 COPY --from=build /app/scripts ./scripts
 COPY --from=build /app/assets ./assets
 
-ENV NAVIDROME_CONFIG_PATH=/config/settings.json
-RUN mkdir -p /config && chown -R node:node /config
-VOLUME ["/config"]
-USER node
-
 EXPOSE 3000
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD node -e "require('http').get('http://127.0.0.1:3000/mcp',r=>process.exit(r.statusCode?0:1)).on('error',()=>process.exit(1))"
-
+USER node
 CMD ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,6 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --prod --frozen-lockfile --ignore-scripts
 
 COPY --from=build /app/dist ./dist
-COPY --from=build /app/scripts ./scripts
-COPY --from=build /app/assets ./assets
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+
+# =================================================================================================
+# Build Stage
+# =================================================================================================
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml ./
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --ignore-scripts
+
+COPY . .
+RUN pnpm build
+
+
+# =================================================================================================
+# Runtime Stage
+# =================================================================================================
+FROM node:22-bookworm-slim AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml ./
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --prod --frozen-lockfile --ignore-scripts
+
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/scripts ./scripts
+COPY --from=build /app/assets ./assets
+
+ENV NAVIDROME_CONFIG_PATH=/config/settings.json
+RUN mkdir -p /config && chown -R node:node /config
+VOLUME ["/config"]
+USER node
+
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "require('http').get('http://127.0.0.1:3000/mcp',r=>process.exit(r.statusCode?0:1)).on('error',()=>process.exit(1))"
+
+CMD ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,5 +41,9 @@ COPY --from=build /app/scripts ./scripts
 COPY --from=build /app/assets ./assets
 
 EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["node", "-e", "require('node:http').get('http://127.0.0.1:3000/healthz',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+
 USER node
 CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ client at that URL:
 }
 ```
 
+In HTTP mode the server also exposes an unauthenticated liveness endpoint at
+`GET /healthz` (returns `200 {"status":"ok"}`) for container/orchestrator health
+checks — it reports only that the HTTP server is up, and performs no Navidrome call.
+
 On first run the settings form also pre-fills the transport from these environment
 variables (import-only, like all other settings): `MCP_TRANSPORT` (`stdio`|`http`),
 `MCP_HTTP_HOST`, and `MCP_HTTP_PORT`.

--- a/README.md
+++ b/README.md
@@ -172,13 +172,14 @@ at `/mcp` instead. This lets you run it as a standalone, always-on process — f
 a container in the same Kubernetes namespace as Navidrome — and point networked MCP
 clients at it directly, with no external `supergateway`/`mcp-proxy` bridge.
 
-Add a `transport` block to your `settings.json`:
+Add a `transport` block to your `settings.json`. `host` defaults to `127.0.0.1`
+(loopback only); set `expose: true` to bind all interfaces (`0.0.0.0`) so a remote or in-cluster client can reach it; an explicit `host` overrides this:
 
 ```json
 "transport": {
   "type": "http",
-  "host": "0.0.0.0",
-  "port": 3000
+  "port": 3000,
+  "expose": true
 }
 ```
 
@@ -202,21 +203,22 @@ checks — it reports only that the HTTP server is up, and performs no Navidrome
 
 On first run the settings form also pre-fills the transport from these environment
 variables (import-only, like all other settings): `MCP_TRANSPORT` (`stdio`|`http`),
-`MCP_HTTP_HOST`, and `MCP_HTTP_PORT`.
+`MCP_HTTP_HOST`, `MCP_HTTP_PORT`, and `MCP_HTTP_EXPOSE` (`true` to bind all interfaces).
 
-> **Security:** `host` defaults to `0.0.0.0` because choosing HTTP is itself the opt-in to
-> network exposure, and the server has **no built-in authentication**. Anyone who can reach
-> the port can drive your Navidrome library. Restrict access with a Kubernetes
-> NetworkPolicy, a firewall, or a reverse proxy that adds authentication/TLS — or bind
-> `host` to a specific interface. Keep the default `stdio` transport unless you
-> specifically need remote access.
+> **Security:** the HTTP transport binds **loopback (`127.0.0.1`) by default** and has **no
+> built-in authentication** — the server holds an already-authenticated Navidrome session,
+> so an open port is full library control with no credential. Exposing it beyond localhost
+> is a deliberate opt-in (`expose: true`, or an explicit non-loopback `host`). When you do,
+> restrict access with a Kubernetes NetworkPolicy, a firewall, or a reverse proxy that adds
+> authentication/TLS. Keep the default `stdio` transport unless you specifically need remote
+> access.
 
 #### Running in Docker
 
 A [`Dockerfile`](Dockerfile) is included for exactly this HTTP-transport use case. The
 image reads its config from a mounted `settings.json` (it points
-`NAVIDROME_CONFIG_PATH` at `/config/settings.json`), so create one with the
-`transport.type` set to `http`, then mount it:
+`NAVIDROME_CONFIG_PATH` at `/config/settings.json`), so create one with `transport.type`
+set to `http` and `transport.expose: true` — a container must bind `0.0.0.0` (not the default loopback) to be reachable through the published port — then mount it:
 
 ```bash
 docker build -t navidrome-mcp .
@@ -225,9 +227,8 @@ docker run --rm -p 3000:3000 \
   navidrome-mcp
 ```
 
-The MCP endpoint is then at `http://localhost:3000/mcp`. The container runs as a
-non-root user and ships a healthcheck against the endpoint. (mpv playback isn't included
-in the image — it's meant as a headless, networked MCP server.)
+The MCP endpoint is then at `http://localhost:3000/mcp`, with the `GET /healthz` liveness endpoint available for an orchestrator probe. The container runs as a non-root user. (mpv
+playback isn't included in the image — it's meant as a headless, networked MCP server.)
 
 ### Installing mpv (optional)
 

--- a/README.md
+++ b/README.md
@@ -244,8 +244,18 @@ variables (import-only, like all other settings): `MCP_TRANSPORT` (`stdio`|`http
 
 A [`Dockerfile`](Dockerfile) is included for exactly this HTTP-transport use case. The
 image reads its config from a mounted `settings.json` (it points
-`NAVIDROME_CONFIG_PATH` at `/config/settings.json`), so create one with `transport.type`
-set to `http` and `transport.expose: true` — a container must bind `0.0.0.0` (not the default loopback) to be reachable through the published port — then mount it:
+`NAVIDROME_CONFIG_PATH` at `/config/settings.json`).
+
+> **Required config — the container does nothing useful without it.** The image runs the
+> same binary as everywhere else, which defaults to **stdio**. Mounted with a `settings.json`
+> that leaves `transport.type` at `stdio`, the container starts, binds **no socket**, and
+> never serves `/mcp` or `/healthz` — it just sits there "Up". You **must** set
+> `transport.type: "http"` and `transport.expose: true` (a container has to bind `0.0.0.0`,
+> not the default loopback, to be reachable through the published port). The bundled
+> `HEALTHCHECK` polls `/healthz`, so a container left in stdio mode shows as **unhealthy**
+> rather than silently broken.
+
+Create the `settings.json`, then mount it:
 
 ```bash
 docker build -t navidrome-mcp .
@@ -258,6 +268,62 @@ The MCP endpoint is then at `http://localhost:3000/mcp`. The image ships a Docke
 `HEALTHCHECK` that polls `GET /healthz` on port 3000 (so `docker ps` shows `healthy`;
 orchestrators can use the same endpoint), and runs as a non-root user. (mpv playback isn't
 included in the image — it's meant as a headless, networked MCP server.)
+
+#### Running in Kubernetes
+
+The image expects `settings.json` at `/config/settings.json`. Since that file holds
+plaintext credentials, store it in a `Secret` and mount it (a `ConfigMap` would expose the
+credentials). Use a `livenessProbe` against `/healthz`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: navidrome-mcp
+type: Opaque
+stringData:
+  settings.json: |
+    {
+      "navidrome": { "url": "http://navidrome:4533", "username": "mcp", "password": "..." },
+      "transport": {
+        "type": "http",
+        "expose": true,
+        "authToken": "a-long-random-secret",
+        "allowedHosts": ["navidrome-mcp:3000"]
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: navidrome-mcp
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: navidrome-mcp } }
+  template:
+    metadata: { labels: { app: navidrome-mcp } }
+    spec:
+      containers:
+        - name: navidrome-mcp
+          image: ghcr.io/blakeem/navidrome-mcp:latest
+          ports: [{ containerPort: 3000 }]
+          livenessProbe:
+            httpGet: { path: /healthz, port: 3000 }
+          readinessProbe:
+            httpGet: { path: /healthz, port: 3000 }
+          volumeMounts:
+            - { name: config, mountPath: /config, readOnly: true }
+      volumes:
+        - name: config
+          secret:
+            secretName: navidrome-mcp
+            items: [{ key: settings.json, path: settings.json }]
+```
+
+Note `allowedHosts`: with DNS-rebinding protection on, the `host:port` your clients use to
+reach the Service (e.g. `navidrome-mcp:3000`) must be allow-listed, or requests are
+rejected. `env:` is **import-only** (it pre-fills the settings form on first run, not the
+running server), so the mounted `settings.json` is the source of truth in-cluster.
 
 ### Installing mpv (optional)
 

--- a/README.md
+++ b/README.md
@@ -205,14 +205,32 @@ client at that URL (add the `Authorization` header if you set a token):
 }
 ```
 
+**DNS-rebinding protection** is always on for the HTTP transport: requests whose
+`Host` header isn't allow-listed are rejected, so a malicious web page can't drive the
+server through your browser even on loopback. The loopback aliases and the bound
+`host:port` are accepted automatically. If you reach the server through a reverse proxy
+or a Kubernetes Service, add the external `host:port` your clients use to
+`transport.allowedHosts` (otherwise legitimate requests get rejected), e.g.:
+
+```json
+"transport": {
+  "type": "http",
+  "expose": true,
+  "allowedHosts": ["navidrome-mcp.media.svc.cluster.local:3000", "mcp.example.com"]
+}
+```
+
+Set `transport.allowedOrigins` only for browser clients (it gates the `Origin` header).
+
 In HTTP mode the server also exposes an unauthenticated liveness endpoint at
 `GET /healthz` (returns `200 {"status":"ok"}`) for container/orchestrator health
 checks — it reports only that the HTTP server is up, and performs no Navidrome call.
 
 On first run the settings form also pre-fills the transport from these environment
 variables (import-only, like all other settings): `MCP_TRANSPORT` (`stdio`|`http`),
-`MCP_HTTP_HOST`, `MCP_HTTP_PORT`, `MCP_HTTP_EXPOSE` (`true` to bind all interfaces), and
-`MCP_HTTP_AUTH_TOKEN`.
+`MCP_HTTP_HOST`, `MCP_HTTP_PORT`, `MCP_HTTP_EXPOSE` (`true` to bind all interfaces),
+`MCP_HTTP_AUTH_TOKEN`, and `MCP_HTTP_ALLOWED_HOSTS` / `MCP_HTTP_ALLOWED_ORIGINS`
+(comma-separated).
 
 > **Security:** the HTTP transport binds **loopback (`127.0.0.1`) by default** and is
 > **unauthenticated unless you set `transport.authToken`** — the server holds an

--- a/README.md
+++ b/README.md
@@ -156,8 +156,56 @@ save.
 - **mpv path:** point at the mpv binary if it's not on `PATH`; blank auto-detects.
 - **Transcode format:** defaults to `raw` (streams the original file untouched for best quality and reliable seeking). Set a codec (e.g. `mp3`, `opus`) to transcode for slow/metered links; the bitrate applies then.
 - **Web UI** (port / host / expose / enabled / auto-open browser): configures the [MPV Remote web UI](#mpv-remote-web-ui) (defaults to `localhost:8808`).
+- **Transport** (type / host / port): how the server exposes the MCP protocol itself. Defaults to `stdio` (the standard local-process transport every desktop client uses). Set `type` to `http` to serve the [Streamable HTTP transport](#running-over-http-containers--remote-clients) instead — for running the server as a long-lived process that remote clients connect to over the network.
 
 Features turn on automatically when their settings are present. Restart your MCP client after saving.
+
+### Running over HTTP (containers / remote clients)
+
+By default the server speaks MCP over **stdio**: the client launches it as a child
+process and talks to it over stdin/stdout. That's ideal for a desktop client on the same
+machine, but it can't be reached over a network.
+
+Setting the transport to **`http`** makes the server bind a socket and serve the MCP
+[Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http)
+at `/mcp` instead. This lets you run it as a standalone, always-on process — for example
+a container in the same Kubernetes namespace as Navidrome — and point networked MCP
+clients at it directly, with no external `supergateway`/`mcp-proxy` bridge.
+
+Add a `transport` block to your `settings.json`:
+
+```json
+"transport": {
+  "type": "http",
+  "host": "0.0.0.0",
+  "port": 3000
+}
+```
+
+The MCP endpoint is then served at `http://<host>:<port>/mcp`. Point an HTTP-capable MCP
+client at that URL:
+
+```json
+{
+  "mcpServers": {
+    "navidrome": {
+      "type": "http",
+      "url": "http://your-host:3000/mcp"
+    }
+  }
+}
+```
+
+On first run the settings form also pre-fills the transport from these environment
+variables (import-only, like all other settings): `MCP_TRANSPORT` (`stdio`|`http`),
+`MCP_HTTP_HOST`, and `MCP_HTTP_PORT`.
+
+> **Security:** `host` defaults to `0.0.0.0` because choosing HTTP is itself the opt-in to
+> network exposure, and the server has **no built-in authentication**. Anyone who can reach
+> the port can drive your Navidrome library. Restrict access with a Kubernetes
+> NetworkPolicy, a firewall, or a reverse proxy that adds authentication/TLS — or bind
+> `host` to a specific interface. Keep the default `stdio` transport unless you
+> specifically need remote access.
 
 ### Installing mpv (optional)
 
@@ -195,7 +243,7 @@ Or a pre-built binary from [mpv.io](https://mpv.io/installation/). Verify with `
 
 ### A Note on ChatGPT Desktop
 
-ChatGPT's MCP support (web and desktop) requires a hosted HTTPS endpoint and isn't compatible with local stdio servers like this one. You can bridge a stdio server to HTTPS with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote), but for a self-hosted music server it's simpler to use Claude Desktop, Claude Code, Cursor, or another client with native stdio support.
+ChatGPT's MCP support (web and desktop) requires a hosted HTTPS endpoint and isn't compatible with local stdio servers. This server can now serve MCP directly over HTTP — see [Running over HTTP](#running-over-http-containers--remote-clients) — so you can host it behind a reverse proxy that terminates TLS instead of reaching for an external bridge like [`mcp-remote`](https://www.npmjs.com/package/mcp-remote). For a self-hosted music server, though, it's still simplest to use Claude Desktop, Claude Code, Cursor, or another client with native stdio support.
 
 ## MPV Remote (Web UI)
 

--- a/README.md
+++ b/README.md
@@ -254,8 +254,10 @@ docker run --rm -p 3000:3000 \
   navidrome-mcp
 ```
 
-The MCP endpoint is then at `http://localhost:3000/mcp`, with the `GET /healthz` liveness endpoint available for an orchestrator probe. The container runs as a non-root user. (mpv
-playback isn't included in the image — it's meant as a headless, networked MCP server.)
+The MCP endpoint is then at `http://localhost:3000/mcp`. The image ships a Docker
+`HEALTHCHECK` that polls `GET /healthz` on port 3000 (so `docker ps` shows `healthy`;
+orchestrators can use the same endpoint), and runs as a non-root user. (mpv playback isn't
+included in the image — it's meant as a headless, networked MCP server.)
 
 ### Installing mpv (optional)
 

--- a/README.md
+++ b/README.md
@@ -173,25 +173,33 @@ a container in the same Kubernetes namespace as Navidrome — and point networke
 clients at it directly, with no external `supergateway`/`mcp-proxy` bridge.
 
 Add a `transport` block to your `settings.json`. `host` defaults to `127.0.0.1`
-(loopback only); set `expose: true` to bind all interfaces (`0.0.0.0`) so a remote or in-cluster client can reach it; an explicit `host` overrides this:
+(loopback only); set `expose: true` to bind all interfaces (`0.0.0.0`) so a remote or in-cluster client can reach it; an explicit `host` overrides this. Set `authToken` to require bearer auth (recommended whenever the port is reachable beyond loopback):
 
 ```json
 "transport": {
   "type": "http",
   "port": 3000,
-  "expose": true
+  "expose": true,
+  "authToken": "a-long-random-secret"
 }
 ```
 
+The settings page has a **Generate** button next to the auth-token field. When a token is
+set, every `/mcp` request must carry `Authorization: Bearer <token>` (compared in constant
+time); anything else gets a `401`. `/healthz` is never gated. If the transport binds a
+non-loopback address with **no** token, the server logs a loud warning at startup rather
+than refusing to start, so a NetworkPolicy-locked deployment keeps zero-friction.
+
 The MCP endpoint is then served at `http://<host>:<port>/mcp`. Point an HTTP-capable MCP
-client at that URL:
+client at that URL (add the `Authorization` header if you set a token):
 
 ```json
 {
   "mcpServers": {
     "navidrome": {
       "type": "http",
-      "url": "http://your-host:3000/mcp"
+      "url": "http://your-host:3000/mcp",
+      "headers": { "Authorization": "Bearer a-long-random-secret" }
     }
   }
 }
@@ -203,15 +211,16 @@ checks — it reports only that the HTTP server is up, and performs no Navidrome
 
 On first run the settings form also pre-fills the transport from these environment
 variables (import-only, like all other settings): `MCP_TRANSPORT` (`stdio`|`http`),
-`MCP_HTTP_HOST`, `MCP_HTTP_PORT`, and `MCP_HTTP_EXPOSE` (`true` to bind all interfaces).
+`MCP_HTTP_HOST`, `MCP_HTTP_PORT`, `MCP_HTTP_EXPOSE` (`true` to bind all interfaces), and
+`MCP_HTTP_AUTH_TOKEN`.
 
-> **Security:** the HTTP transport binds **loopback (`127.0.0.1`) by default** and has **no
-> built-in authentication** — the server holds an already-authenticated Navidrome session,
-> so an open port is full library control with no credential. Exposing it beyond localhost
-> is a deliberate opt-in (`expose: true`, or an explicit non-loopback `host`). When you do,
-> restrict access with a Kubernetes NetworkPolicy, a firewall, or a reverse proxy that adds
-> authentication/TLS. Keep the default `stdio` transport unless you specifically need remote
-> access.
+> **Security:** the HTTP transport binds **loopback (`127.0.0.1`) by default** and is
+> **unauthenticated unless you set `transport.authToken`** — the server holds an
+> already-authenticated Navidrome session, so an open port is full library control with no
+> credential. Exposing it beyond localhost is a deliberate opt-in (`expose: true`, or an
+> explicit non-loopback `host`); when you do, set an auth token **and/or** restrict access
+> with a Kubernetes NetworkPolicy, a firewall, or a reverse proxy that adds TLS. Keep the
+> default `stdio` transport unless you specifically need remote access.
 
 #### Running in Docker
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,24 @@ variables (import-only, like all other settings): `MCP_TRANSPORT` (`stdio`|`http
 > `host` to a specific interface. Keep the default `stdio` transport unless you
 > specifically need remote access.
 
+#### Running in Docker
+
+A [`Dockerfile`](Dockerfile) is included for exactly this HTTP-transport use case. The
+image reads its config from a mounted `settings.json` (it points
+`NAVIDROME_CONFIG_PATH` at `/config/settings.json`), so create one with the
+`transport.type` set to `http`, then mount it:
+
+```bash
+docker build -t navidrome-mcp .
+docker run --rm -p 3000:3000 \
+  -v "$PWD/settings.json:/config/settings.json:ro" \
+  navidrome-mcp
+```
+
+The MCP endpoint is then at `http://localhost:3000/mcp`. The container runs as a
+non-root user and ships a healthcheck against the endpoint. (mpv playback isn't included
+in the image — it's meant as a headless, networked MCP server.)
+
 ### Installing mpv (optional)
 
 mpv is a lightweight, cross-platform media player. When detected at startup, the server registers an additional set of playback tools so audio streams through your machine's speakers. Without it, the server still manages your library and Navidrome's saved queue; it just doesn't produce audio.

--- a/settings.example.json
+++ b/settings.example.json
@@ -8,7 +8,8 @@
     "type": "stdio",
     "host": "127.0.0.1",
     "port": 3000,
-    "expose": false
+    "expose": false,
+    "authToken": ""
   },
   "library": {
     "defaultLibraryIds": [],

--- a/settings.example.json
+++ b/settings.example.json
@@ -6,8 +6,9 @@
   },
   "transport": {
     "type": "stdio",
-    "host": "0.0.0.0",
-    "port": 3000
+    "host": "127.0.0.1",
+    "port": 3000,
+    "expose": false
   },
   "library": {
     "defaultLibraryIds": [],

--- a/settings.example.json
+++ b/settings.example.json
@@ -4,6 +4,11 @@
     "username": "your_username",
     "password": "your_password"
   },
+  "transport": {
+    "type": "stdio",
+    "host": "0.0.0.0",
+    "port": 3000
+  },
   "library": {
     "defaultLibraryIds": [],
     "filterCacheEnabled": true

--- a/src/config-app/public/app.js
+++ b/src/config-app/public/app.js
@@ -16,6 +16,7 @@ const FIELDS = [
   ['transport.type', 'transportType', 'string', 'stdio'],
   ['transport.host', 'transportHost', 'stringOrNull'],
   ['transport.port', 'transportPort', 'int', 3000],
+  ['transport.expose', 'transportExpose', 'bool', false],
   ['features.lastFmApiKey', 'lastFmApiKey', 'stringOrNull'],
   ['features.musicBrainzUserAgent', 'musicBrainzUserAgent', 'stringOrNull'],
   ['features.radioBrowserUserAgent', 'radioBrowserUserAgent', 'stringOrNull'],

--- a/src/config-app/public/app.js
+++ b/src/config-app/public/app.js
@@ -17,6 +17,7 @@ const FIELDS = [
   ['transport.host', 'transportHost', 'stringOrNull'],
   ['transport.port', 'transportPort', 'int', 3000],
   ['transport.expose', 'transportExpose', 'bool', false],
+  ['transport.authToken', 'transportAuthToken', 'stringOrNull'],
   ['features.lastFmApiKey', 'lastFmApiKey', 'stringOrNull'],
   ['features.musicBrainzUserAgent', 'musicBrainzUserAgent', 'stringOrNull'],
   ['features.radioBrowserUserAgent', 'radioBrowserUserAgent', 'stringOrNull'],
@@ -227,6 +228,19 @@ async function init() {
   }
   document.getElementById('test-btn').addEventListener('click', onTest);
   document.getElementById('settings-form').addEventListener('submit', onSave);
+  const genBtn = document.getElementById('transportAuthTokenGen');
+  if (genBtn) genBtn.addEventListener('click', generateAuthToken);
+}
+
+/* Fill the auth-token field with a fresh 256-bit random token (hex). Shown as
+ * plaintext on generation so the user can copy it for their client config. */
+function generateAuthToken() {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  const token = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  const el = document.getElementById('transportAuthToken');
+  el.type = 'text';
+  el.value = token;
 }
 
 init();

--- a/src/config-app/public/app.js
+++ b/src/config-app/public/app.js
@@ -18,6 +18,8 @@ const FIELDS = [
   ['transport.port', 'transportPort', 'int', 3000],
   ['transport.expose', 'transportExpose', 'bool', false],
   ['transport.authToken', 'transportAuthToken', 'stringOrNull'],
+  ['transport.allowedHosts', 'transportAllowedHosts', 'csvStringArray'],
+  ['transport.allowedOrigins', 'transportAllowedOrigins', 'csvStringArray'],
   ['features.lastFmApiKey', 'lastFmApiKey', 'stringOrNull'],
   ['features.musicBrainzUserAgent', 'musicBrainzUserAgent', 'stringOrNull'],
   ['features.radioBrowserUserAgent', 'radioBrowserUserAgent', 'stringOrNull'],
@@ -65,6 +67,9 @@ function populate(seed) {
       case 'csvIntArray':
         el.value = Array.isArray(raw) ? raw.join(',') : '';
         break;
+      case 'csvStringArray':
+        el.value = Array.isArray(raw) ? raw.join(', ') : '';
+        break;
       case 'int':
         el.value = raw == null ? '' : String(raw);
         break;
@@ -105,6 +110,12 @@ function collect() {
           .split(',')
           .map((t) => parseInt(t.trim(), 10))
           .filter((n) => Number.isFinite(n));
+        break;
+      case 'csvStringArray':
+        value = el.value
+          .split(',')
+          .map((t) => t.trim())
+          .filter((t) => t !== '');
         break;
       default:
         value = el.value;

--- a/src/config-app/public/app.js
+++ b/src/config-app/public/app.js
@@ -13,6 +13,9 @@ const FIELDS = [
   ['navidrome.password', 'password', 'string'],
   ['library.defaultLibraryIds', 'defaultLibraries', 'csvIntArray'],
   ['library.filterCacheEnabled', 'filterCacheEnabled', 'bool', true],
+  ['transport.type', 'transportType', 'string', 'stdio'],
+  ['transport.host', 'transportHost', 'stringOrNull'],
+  ['transport.port', 'transportPort', 'int', 3000],
   ['features.lastFmApiKey', 'lastFmApiKey', 'stringOrNull'],
   ['features.musicBrainzUserAgent', 'musicBrainzUserAgent', 'stringOrNull'],
   ['features.radioBrowserUserAgent', 'radioBrowserUserAgent', 'stringOrNull'],
@@ -64,7 +67,10 @@ function populate(seed) {
         el.value = raw == null ? '' : String(raw);
         break;
       default: // string | stringOrNull
-        el.value = raw == null ? '' : String(raw);
+        // Fall back to the declared default when the seed has no value, so a
+        // <select> (e.g. transport.type) lands on a valid option instead of an
+        // empty/-1 selection. Text inputs without a default just stay blank.
+        el.value = raw == null ? (dflt == null ? '' : String(dflt)) : String(raw);
     }
   }
 }

--- a/src/config-app/public/index.html
+++ b/src/config-app/public/index.html
@@ -46,13 +46,17 @@
             <option value="http">http (Streamable HTTP)</option>
           </select>
         </label>
-        <label>Bind host <span class="hint">http only — blank means <code>0.0.0.0</code> (all interfaces)</span>
-          <input id="transportHost" type="text" placeholder="0.0.0.0" />
+        <label>Bind host <span class="hint">http only — blank stays on <code>127.0.0.1</code> (loopback) unless "Expose" is set</span>
+          <input id="transportHost" type="text" placeholder="127.0.0.1" />
         </label>
         <label>Port <span class="hint">http only</span>
           <input id="transportPort" type="number" min="1" max="65535" placeholder="3000" />
         </label>
-        <p class="hint"><span class="warn">http has no built-in auth</span> — anyone who can reach the port controls your library. Restrict access with a firewall, network policy, or an authenticating reverse proxy.</p>
+        <label class="check">
+          <input id="transportExpose" type="checkbox" />
+          <span>Expose on network <span class="warn">binds <code>0.0.0.0</code> (all interfaces) — http has no auth, so anyone who can reach the port gets full library control</span></span>
+        </label>
+        <p class="hint">Leave http unexposed unless you front it with a firewall, network policy, or an authenticating reverse proxy. Setting an explicit bind host overrides this.</p>
       </section>
 
       <section class="card">

--- a/src/config-app/public/index.html
+++ b/src/config-app/public/index.html
@@ -54,9 +54,15 @@
         </label>
         <label class="check">
           <input id="transportExpose" type="checkbox" />
-          <span>Expose on network <span class="warn">binds <code>0.0.0.0</code> (all interfaces) — http has no auth, so anyone who can reach the port gets full library control</span></span>
+          <span>Expose on network <span class="warn">binds <code>0.0.0.0</code> (all interfaces) — anyone who can reach the port gets full library control unless you set an auth token below</span></span>
         </label>
-        <p class="hint">Leave http unexposed unless you front it with a firewall, network policy, or an authenticating reverse proxy. Setting an explicit bind host overrides this.</p>
+        <label>Auth token <span class="hint">http only — when set, clients must send <code>Authorization: Bearer &lt;token&gt;</code>. Leave blank for no auth (loopback / network-policy-locked only).</span>
+          <span class="with-btn">
+            <input id="transportAuthToken" type="password" placeholder="(no auth)" autocomplete="off" />
+            <button type="button" id="transportAuthTokenGen" class="btn secondary">Generate</button>
+          </span>
+        </label>
+        <p class="hint">Leave http unexposed unless you set an auth token, or front it with a firewall, network policy, or an authenticating reverse proxy. Setting an explicit bind host overrides the expose toggle.</p>
       </section>
 
       <section class="card">

--- a/src/config-app/public/index.html
+++ b/src/config-app/public/index.html
@@ -62,6 +62,12 @@
             <button type="button" id="transportAuthTokenGen" class="btn secondary">Generate</button>
           </span>
         </label>
+        <label>Allowed hosts <span class="hint">http only — DNS-rebinding protection is always on; loopback and the bound <code>host:port</code> are allowed automatically. Behind a proxy / k8s Service, list the external <code>host:port</code> clients use, comma-separated (e.g. <code>mcp.example.com:3000</code>).</span>
+          <input id="transportAllowedHosts" type="text" placeholder="(auto)" />
+        </label>
+        <label>Allowed origins <span class="hint">http only — only needed for browser clients; comma-separated <code>Origin</code> values to accept</span>
+          <input id="transportAllowedOrigins" type="text" placeholder="(none)" />
+        </label>
         <p class="hint">Leave http unexposed unless you set an auth token, or front it with a firewall, network policy, or an authenticating reverse proxy. Setting an explicit bind host overrides the expose toggle.</p>
       </section>
 

--- a/src/config-app/public/index.html
+++ b/src/config-app/public/index.html
@@ -39,6 +39,23 @@
       </section>
 
       <section class="card">
+        <h2>MCP transport</h2>
+        <label>Type <span class="hint"><code>stdio</code> = launched locally by your client (default); <code>http</code> = serve over the network at <code>/mcp</code> for remote/containerized clients</span>
+          <select id="transportType">
+            <option value="stdio">stdio (local process)</option>
+            <option value="http">http (Streamable HTTP)</option>
+          </select>
+        </label>
+        <label>Bind host <span class="hint">http only — blank means <code>0.0.0.0</code> (all interfaces)</span>
+          <input id="transportHost" type="text" placeholder="0.0.0.0" />
+        </label>
+        <label>Port <span class="hint">http only</span>
+          <input id="transportPort" type="number" min="1" max="65535" placeholder="3000" />
+        </label>
+        <p class="hint"><span class="warn">http has no built-in auth</span> — anyone who can reach the port controls your library. Restrict access with a firewall, network policy, or an authenticating reverse proxy.</p>
+      </section>
+
+      <section class="card">
         <h2>Music discovery — Last.fm <span class="opt">optional</span></h2>
         <label>API key <span class="hint">enables similar artists/tracks, bios, charts — <a href="https://www.last.fm/api/account/create" target="_blank" rel="noopener noreferrer">get a free key here</a></span>
           <input id="lastFmApiKey" type="text" placeholder="(disabled)" />

--- a/src/config-app/public/styles.css
+++ b/src/config-app/public/styles.css
@@ -91,6 +91,10 @@ label.check { display: flex; align-items: flex-start; gap: 10px; }
 label.check input { width: auto; margin-top: 3px; }
 label.check span { font-weight: 400; }
 
+.with-btn { display: flex; gap: 8px; align-items: stretch; }
+.with-btn input { flex: 1; }
+.with-btn .btn { flex: 0 0 auto; white-space: nowrap; }
+
 .actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 18px; }
 .btn {
   padding: 10px 18px;

--- a/src/config-app/routes.ts
+++ b/src/config-app/routes.ts
@@ -161,14 +161,19 @@ async function parseSettingsBody(req: IncomingMessage, res: ServerResponse): Pro
   return unmaskSecrets(result.data);
 }
 
-/** Replace the real password with the sentinel for safe display. */
+/** Replace stored secrets (Navidrome password, MCP auth token) with the sentinel
+ * for safe display. */
 function maskSecrets(settings: SettingsFile): SettingsFile {
+  let masked = settings;
   const password = settings.navidrome?.password;
-  if (password === undefined || password === '') return settings;
-  return {
-    ...settings,
-    navidrome: { ...settings.navidrome, password: PASSWORD_SENTINEL },
-  };
+  if (password !== undefined && password !== '') {
+    masked = { ...masked, navidrome: { ...masked.navidrome, password: PASSWORD_SENTINEL } };
+  }
+  const authToken = settings.transport?.authToken;
+  if (authToken !== undefined && authToken !== null && authToken !== '') {
+    masked = { ...masked, transport: { ...masked.transport, authToken: PASSWORD_SENTINEL } };
+  }
+  return masked;
 }
 
 /**
@@ -181,12 +186,19 @@ function maskSecrets(settings: SettingsFile): SettingsFile {
  * looked filled — the seed is the correct source.
  */
 function unmaskSecrets(settings: SettingsFile): SettingsFile {
-  if (settings.navidrome?.password !== PASSWORD_SENTINEL) return settings;
-  const stored = buildFormSeed().navidrome?.password ?? '';
-  return {
-    ...settings,
-    navidrome: { ...settings.navidrome, password: stored },
-  };
+  let result = settings;
+  // Read both secrets from the SAME source the form was seeded from.
+  let seed: SettingsFile | undefined;
+  const seeded = (): SettingsFile => (seed ??= buildFormSeed());
+  if (result.navidrome?.password === PASSWORD_SENTINEL) {
+    const stored = seeded().navidrome?.password ?? '';
+    result = { ...result, navidrome: { ...result.navidrome, password: stored } };
+  }
+  if (result.transport?.authToken === PASSWORD_SENTINEL) {
+    const stored = seeded().transport?.authToken ?? null;
+    result = { ...result, transport: { ...result.transport, authToken: stored } };
+  }
+  return result;
 }
 
 function extractMessage(err: unknown): string {

--- a/src/config/map-config.ts
+++ b/src/config/map-config.ts
@@ -42,6 +42,7 @@ function nonEmpty(value: string | null | undefined): string | undefined {
  */
 export function mapStoreToConfig(settings: SettingsFile): RawConfigInput {
   const nav = settings.navidrome ?? {};
+  const transport = settings.transport ?? {};
   const features = settings.features ?? {};
   const playback = settings.playback ?? {};
   const webui = settings.webui ?? {};
@@ -75,6 +76,12 @@ export function mapStoreToConfig(settings: SettingsFile): RawConfigInput {
     debug: advanced.debug ?? false,
     cacheTtl: advanced.cacheTtl ?? 300,
     tokenExpiry: advanced.tokenExpiry ?? 86400,
+
+    transport: {
+      type: transport.type ?? 'stdio',
+      host: nonEmpty(transport.host) ?? '0.0.0.0',
+      port: transport.port ?? 3000,
+    },
 
     defaultLibraryIds,
 

--- a/src/config/map-config.ts
+++ b/src/config/map-config.ts
@@ -69,6 +69,12 @@ export function mapStoreToConfig(settings: SettingsFile): RawConfigInput {
   const explicitHost = nonEmpty(webui.host);
   const host = explicitHost ?? (expose ? '0.0.0.0' : '127.0.0.1');
 
+  // transport host: same model as the webui above — loopback by default, an
+  // explicit host wins, and `expose` is the deliberate opt-in to 0.0.0.0.
+  const transportExpose = transport.expose ?? false;
+  const transportExplicitHost = nonEmpty(transport.host);
+  const transportHost = transportExplicitHost ?? (transportExpose ? '0.0.0.0' : '127.0.0.1');
+
   return {
     navidromeUrl: nav.url ?? '',
     navidromeUsername: nav.username ?? '',
@@ -79,8 +85,9 @@ export function mapStoreToConfig(settings: SettingsFile): RawConfigInput {
 
     transport: {
       type: transport.type ?? 'stdio',
-      host: nonEmpty(transport.host) ?? '0.0.0.0',
+      host: transportHost,
       port: transport.port ?? 3000,
+      expose: transportExpose,
     },
 
     defaultLibraryIds,

--- a/src/config/map-config.ts
+++ b/src/config/map-config.ts
@@ -88,6 +88,7 @@ export function mapStoreToConfig(settings: SettingsFile): RawConfigInput {
       host: transportHost,
       port: transport.port ?? 3000,
       expose: transportExpose,
+      authToken: nonEmpty(transport.authToken),
     },
 
     defaultLibraryIds,

--- a/src/config/map-config.ts
+++ b/src/config/map-config.ts
@@ -32,6 +32,13 @@ function nonEmpty(value: string | null | undefined): string | undefined {
   return trimmed === '' ? undefined : trimmed;
 }
 
+/** Trim a string list, drop blanks, and collapse an empty result to `undefined`. */
+function cleanList(value: readonly (string | null | undefined)[] | null | undefined): string[] | undefined {
+  if (value === null || value === undefined) return undefined;
+  const cleaned = value.map((v) => v?.trim()).filter((v): v is string => v !== undefined && v !== '');
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
 /**
  * Project the nested store into the flat `RawConfigInput` that `ConfigSchema`
  * validates. The single place the nested→flat translation lives, shared by
@@ -89,6 +96,8 @@ export function mapStoreToConfig(settings: SettingsFile): RawConfigInput {
       port: transport.port ?? 3000,
       expose: transportExpose,
       authToken: nonEmpty(transport.authToken),
+      allowedHosts: cleanList(transport.allowedHosts),
+      allowedOrigins: cleanList(transport.allowedOrigins),
     },
 
     defaultLibraryIds,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -37,6 +37,21 @@ export const ConfigSchema = z.object({
   cacheTtl: z.number().positive().default(300),
   tokenExpiry: z.number().positive().default(86400), // Default 24 hours in seconds
 
+  // MCP Transport Configuration — how the MCP server exposes itself to clients.
+  // 'stdio' (default) is the classic local-process transport every desktop MCP
+  // client speaks; nothing binds a socket. 'http' serves the MCP Streamable HTTP
+  // transport on `host:port` so the server can run as a long-lived process
+  // (e.g. a container in a cluster) that remote clients connect to over HTTP —
+  // removing the need to wrap it in an external bridge like `supergateway`.
+  // `host` defaults to 0.0.0.0 because choosing 'http' is itself the opt-in to
+  // network exposure (the local-only default lives in 'stdio'); secure it with
+  // network policy / a reverse proxy. The MCP endpoint is served at `/mcp`.
+  transport: z.object({
+    type: z.enum(['stdio', 'http']).default('stdio'),
+    host: z.string().default('0.0.0.0'),
+    port: z.number().int().min(1).max(65535).default(3000),
+  }),
+
   // Library Configuration
   defaultLibraryIds: z.array(z.number()).optional(),
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -54,12 +54,19 @@ export const ConfigSchema = z.object({
   // must present `Authorization: Bearer <token>`. Left unset the endpoint is
   // unauthenticated — fine for loopback or a network-policy-locked pod, but the
   // server warns loudly if it binds a non-loopback address without one.
+  //
+  // DNS-rebinding protection is always on for the HTTP transport. The loopback
+  // and bound `host:port` are accepted automatically; a deployment reached
+  // through a proxy / k8s Service must add the external `host:port` clients use
+  // to `allowedHosts`. `allowedOrigins` is only needed for browser clients.
   transport: z.object({
     type: z.enum(['stdio', 'http']).default('stdio'),
     host: z.string().default('127.0.0.1'),
     port: z.number().int().min(1).max(65535).default(3000),
     expose: z.boolean().default(false),
     authToken: z.string().optional(),
+    allowedHosts: z.array(z.string()).optional(),
+    allowedOrigins: z.array(z.string()).optional(),
   }),
 
   // Library Configuration

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -43,13 +43,17 @@ export const ConfigSchema = z.object({
   // transport on `host:port` so the server can run as a long-lived process
   // (e.g. a container in a cluster) that remote clients connect to over HTTP —
   // removing the need to wrap it in an external bridge like `supergateway`.
-  // `host` defaults to 0.0.0.0 because choosing 'http' is itself the opt-in to
-  // network exposure (the local-only default lives in 'stdio'); secure it with
-  // network policy / a reverse proxy. The MCP endpoint is served at `/mcp`.
+  // The MCP endpoint is served at `/mcp`.
+  //
+  // Mirrors the webui exposure model (see below): `host=127.0.0.1` keeps the
+  // endpoint on localhost only. Setting `expose=true` forces the bind to
+  // `0.0.0.0` so a remote/cluster client can reach it; an explicit `host`
+  // overrides this.
   transport: z.object({
     type: z.enum(['stdio', 'http']).default('stdio'),
-    host: z.string().default('0.0.0.0'),
+    host: z.string().default('127.0.0.1'),
     port: z.number().int().min(1).max(65535).default(3000),
+    expose: z.boolean().default(false),
   }),
 
   // Library Configuration

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -49,11 +49,17 @@ export const ConfigSchema = z.object({
   // endpoint on localhost only. Setting `expose=true` forces the bind to
   // `0.0.0.0` so a remote/cluster client can reach it; an explicit `host`
   // overrides this.
+  //
+  // `authToken` (optional) turns on bearer auth: when set, every `/mcp` request
+  // must present `Authorization: Bearer <token>`. Left unset the endpoint is
+  // unauthenticated — fine for loopback or a network-policy-locked pod, but the
+  // server warns loudly if it binds a non-loopback address without one.
   transport: z.object({
     type: z.enum(['stdio', 'http']).default('stdio'),
     host: z.string().default('127.0.0.1'),
     port: z.number().int().min(1).max(65535).default(3000),
     expose: z.boolean().default(false),
+    authToken: z.string().optional(),
   }),
 
   // Library Configuration

--- a/src/config/seed.ts
+++ b/src/config/seed.ts
@@ -103,6 +103,7 @@ function importFromLegacyEnv(): SettingsFile {
       host: get('MCP_HTTP_HOST') ?? null,
       port: transportPort,
       expose: get('MCP_HTTP_EXPOSE') === 'true',
+      authToken: get('MCP_HTTP_AUTH_TOKEN') ?? null,
     },
     library: {
       defaultLibraryIds,

--- a/src/config/seed.ts
+++ b/src/config/seed.ts
@@ -104,6 +104,8 @@ function importFromLegacyEnv(): SettingsFile {
       port: transportPort,
       expose: get('MCP_HTTP_EXPOSE') === 'true',
       authToken: get('MCP_HTTP_AUTH_TOKEN') ?? null,
+      allowedHosts: toList(get('MCP_HTTP_ALLOWED_HOSTS')),
+      allowedOrigins: toList(get('MCP_HTTP_ALLOWED_ORIGINS')),
     },
     library: {
       defaultLibraryIds,
@@ -148,6 +150,13 @@ function toInt(value: string | undefined, fallback: number): number {
   if (value === undefined) return fallback;
   const n = parseInt(value, 10);
   return Number.isFinite(n) ? n : fallback;
+}
+
+/** Split a comma-separated env value into a trimmed list, or null when unset. */
+function toList(value: string | undefined): string[] | null {
+  if (value === undefined) return null;
+  const items = value.split(',').map((s) => s.trim()).filter((s) => s !== '');
+  return items.length > 0 ? items : null;
 }
 
 /**

--- a/src/config/seed.ts
+++ b/src/config/seed.ts
@@ -102,6 +102,7 @@ function importFromLegacyEnv(): SettingsFile {
       type: transportType,
       host: get('MCP_HTTP_HOST') ?? null,
       port: transportPort,
+      expose: get('MCP_HTTP_EXPOSE') === 'true',
     },
     library: {
       defaultLibraryIds,

--- a/src/config/seed.ts
+++ b/src/config/seed.ts
@@ -89,11 +89,19 @@ function importFromLegacyEnv(): SettingsFile {
   const cacheTtl = toInt(get('CACHE_TTL'), 300);
   const tokenExpiry = toInt(get('TOKEN_EXPIRY'), 86400);
 
+  const transportType = get('MCP_TRANSPORT') === 'http' ? 'http' : 'stdio';
+  const transportPort = toInt(get('MCP_HTTP_PORT'), 3000);
+
   return {
     navidrome: {
       url: get('NAVIDROME_URL') ?? '',
       username: get('NAVIDROME_USERNAME') ?? '',
       password: get('NAVIDROME_PASSWORD') ?? '',
+    },
+    transport: {
+      type: transportType,
+      host: get('MCP_HTTP_HOST') ?? null,
+      port: transportPort,
     },
     library: {
       defaultLibraryIds,

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -49,6 +49,7 @@ export const SettingsFileSchema = z.object({
     host: z.string().nullish(),
     port: z.number().int().min(1).max(65535).optional(),
     expose: z.boolean().optional(),
+    authToken: z.string().nullish(),
   }).optional(),
   library: z.object({
     defaultLibraryIds: z.array(z.number()).optional(),

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -44,6 +44,11 @@ export const SettingsFileSchema = z.object({
     username: z.string().optional(),
     password: z.string().optional(),
   }).optional(),
+  transport: z.object({
+    type: z.enum(['stdio', 'http']).optional(),
+    host: z.string().nullish(),
+    port: z.number().int().min(1).max(65535).optional(),
+  }).optional(),
   library: z.object({
     defaultLibraryIds: z.array(z.number()).optional(),
     filterCacheEnabled: z.boolean().optional(),

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -48,6 +48,7 @@ export const SettingsFileSchema = z.object({
     type: z.enum(['stdio', 'http']).optional(),
     host: z.string().nullish(),
     port: z.number().int().min(1).max(65535).optional(),
+    expose: z.boolean().optional(),
   }).optional(),
   library: z.object({
     defaultLibraryIds: z.array(z.number()).optional(),

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -50,6 +50,8 @@ export const SettingsFileSchema = z.object({
     port: z.number().int().min(1).max(65535).optional(),
     expose: z.boolean().optional(),
     authToken: z.string().nullish(),
+    allowedHosts: z.array(z.string()).nullish(),
+    allowedOrigins: z.array(z.string()).nullish(),
   }).optional(),
   library: z.object({
     defaultLibraryIds: z.array(z.number()).optional(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,9 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createRuntime } from './bootstrap.js';
-import { resolveConfigState } from './config.js';
+import { resolveConfigState, type Config } from './config.js';
+import { startHttpTransport } from './transport/http.js';
+import type { NavidromeClient } from './client/navidrome-client.js';
 import { registerTools } from './tools/index.js';
 import { registerResources } from './resources/index.js';
 import { playbackEngine } from './services/playback/playback-engine.js';
@@ -42,6 +44,29 @@ process.on('unhandledRejection', (reason) => {
   logger.error('unhandledRejection:', reason);
 });
 
+/**
+ * Build a fully-configured MCP {@link Server}: a fresh instance with all tools
+ * and resources registered against the shared, already-authenticated client.
+ *
+ * Factored out because the Streamable HTTP transport is stateful and needs one
+ * Server per session, while stdio needs exactly one — both call this so the two
+ * paths register an identical surface.
+ */
+function createConfiguredServer(client: NavidromeClient, config: Config): Server {
+  const server = new Server(
+    {
+      name: 'navidrome-mcp',
+      version: getPackageVersion(),
+    },
+    {
+      capabilities: MCP_CAPABILITIES,
+    }
+  );
+  registerTools(server, client, config);
+  registerResources(server, client);
+  return server;
+}
+
 async function main(): Promise<void> {
   try {
     // Add startup diagnostics for troubleshooting. Config now comes from the
@@ -50,16 +75,6 @@ async function main(): Promise<void> {
     logger.debug('Starting Navidrome MCP Server...');
     logger.debug('Node version:', process.version);
     logger.debug('Platform:', process.platform);
-
-    const server = new Server(
-      {
-        name: 'navidrome-mcp',
-        version: getPackageVersion(),
-      },
-      {
-        capabilities: MCP_CAPABILITIES,
-      }
-    );
 
     // First-run / degraded mode: when settings.json has no usable Navidrome URL
     // we cannot build a client. Instead of crashing, start the loopback settings
@@ -73,6 +88,13 @@ async function main(): Promise<void> {
         `Navidrome MCP is not configured. Open the settings page to set it up: ${settings.url}`
       );
       openBrowser(settings.url);
+
+      // Setup mode is inherently local + interactive, so it always uses stdio
+      // (the HTTP transport is opt-in for a configured, headless deployment).
+      const server = new Server(
+        { name: 'navidrome-mcp', version: getPackageVersion() },
+        { capabilities: MCP_CAPABILITIES }
+      );
       registerDegradedTools(server, settings.url);
 
       // Mirror the happy-path handlers: close the config server, then exit with
@@ -102,9 +124,6 @@ async function main(): Promise<void> {
     // library/filter caches, and configures the playback engine. Identical for
     // the MCP server and the future standalone web server.
     const { config, client } = await createRuntime(state.config);
-
-    registerTools(server, client, config);
-    registerResources(server, client);
 
     // Standalone web player (spec §6). Instead of an in-process server, MCP
     // spawns the SAME `navidrome-web` process it would run standalone, as an IPC
@@ -179,10 +198,38 @@ async function main(): Promise<void> {
       process.once('SIGTERM', makeExit(15));
     }
 
-    const transport = new StdioServerTransport();
-    await server.connect(transport);
+    // Bind the configured transport. HTTP serves remote clients over a socket
+    // (one MCP Server per session); stdio serves the single local-process client
+    // the same way it always has.
+    if (config.transport.type === 'http') {
+      const http = await startHttpTransport({
+        host: config.transport.host,
+        port: config.transport.port,
+        createMcpServer: () => createConfiguredServer(client, config),
+      });
 
-    logger.info('Navidrome MCP Server started successfully');
+      // Stop accepting connections on a graceful signal. The playback teardown
+      // handlers above (when registered) already own process.exit; when playback
+      // is off, exit here so the bound socket doesn't keep the process alive.
+      const stopHttp = (signo: number) => (): void => {
+        void (async (): Promise<void> => {
+          try {
+            await http.close();
+          } finally {
+            if (!config.features.playback) process.exit(128 + signo);
+          }
+        })();
+      };
+      process.once('SIGINT', stopHttp(2));
+      process.once('SIGTERM', stopHttp(15));
+
+      logger.info(`Navidrome MCP Server listening on ${http.url} (Streamable HTTP)`);
+    } else {
+      const transport = new StdioServerTransport();
+      const server = createConfiguredServer(client, config);
+      await server.connect(transport);
+      logger.info('Navidrome MCP Server started successfully');
+    }
   } catch (error) {
     // Provide detailed error information for debugging
     logger.error('Failed to start Navidrome MCP Server');

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,6 +220,8 @@ async function main(): Promise<void> {
         host: config.transport.host,
         port: config.transport.port,
         authToken: config.transport.authToken,
+        allowedHosts: config.transport.allowedHosts,
+        allowedOrigins: config.transport.allowedOrigins,
         createMcpServer: () => createConfiguredServer(client, config),
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createRuntime } from './bootstrap.js';
 import { resolveConfigState, type Config } from './config.js';
-import { startHttpTransport } from './transport/http.js';
+import { startHttpTransport, type HttpTransport } from './transport/http.js';
 import type { NavidromeClient } from './client/navidrome-client.js';
 import { registerTools } from './tools/index.js';
 import { registerResources } from './resources/index.js';
@@ -169,38 +169,10 @@ async function main(): Promise<void> {
       }
     }
 
-    // mpv teardown on MCP exit (lifecycle §B.1): mpv stops with its last host.
-    // On a graceful signal, quit mpv IFF no web server is running — when a
-    // `navidrome-web` owns the port (incl. an MCP-spawned child or a persisted
-    // one) it owns mpv and tears it down itself, so MCP must not double-quit.
-    // Covers MCP-only mode and the spawn-failed case. Probe is loopback.
-    if (config.features.playback) {
-      let stopping = false;
-      // Exit with the conventional 128 + signal number so a supervisor sees
-      // signal termination (SIGINT → 130, SIGTERM → 143) rather than a clean
-      // 0 that masks the fact we were killed. Teardown is identical for both.
-      const makeExit = (signo: number) => (): void => {
-        if (stopping) return;
-        stopping = true;
-        void (async (): Promise<void> => {
-          try {
-            if (!(await webOwnerPresent(config.webui.port))) {
-              await playbackEngine.quitMpv();
-              logger.info('MCP exit: no web server owns mpv — quit it');
-            }
-          } catch {
-            /* best-effort */
-          }
-          process.exit(128 + signo);
-        })();
-      };
-      process.once('SIGINT', makeExit(2));
-      process.once('SIGTERM', makeExit(15));
-    }
-
     // Bind the configured transport. HTTP serves remote clients over a socket
     // (one MCP Server per session); stdio serves the single local-process client
     // the same way it always has.
+    let httpHandle: HttpTransport | undefined;
     if (config.transport.type === 'http') {
       // Loud warning for the genuinely unsafe combination: bound to a
       // non-loopback address with no bearer token. We don't refuse to start —
@@ -216,7 +188,7 @@ async function main(): Promise<void> {
         );
       }
 
-      const http = await startHttpTransport({
+      httpHandle = await startHttpTransport({
         host: config.transport.host,
         port: config.transport.port,
         authToken: config.transport.authToken,
@@ -225,27 +197,35 @@ async function main(): Promise<void> {
         createMcpServer: () => createConfiguredServer(client, config),
       });
 
-      // Stop accepting connections on a graceful signal. The playback teardown
-      // handlers above (when registered) already own process.exit; when playback
-      // is off, exit here so the bound socket doesn't keep the process alive.
-      const stopHttp = (signo: number) => (): void => {
-        void (async (): Promise<void> => {
-          try {
-            await http.close();
-          } finally {
-            if (!config.features.playback) process.exit(128 + signo);
-          }
-        })();
-      };
-      process.once('SIGINT', stopHttp(2));
-      process.once('SIGTERM', stopHttp(15));
-
-      logger.info(`Navidrome MCP Server listening on ${http.url} (Streamable HTTP)`);
+      logger.info(`Navidrome MCP Server listening on ${httpHandle.url} (Streamable HTTP)`);
     } else {
       const transport = new StdioServerTransport();
       const server = createConfiguredServer(client, config);
       await server.connect(transport);
       logger.info('Navidrome MCP Server started successfully');
+    }
+
+    if (httpHandle !== undefined || config.features.playback) {
+      let stopping = false;
+      const shutdown = (signo: number) => (): void => {
+        if (stopping) return;
+        stopping = true;
+        void (async (): Promise<void> => {
+          try {
+            if (httpHandle !== undefined) await httpHandle.close();
+            if (config.features.playback && !(await webOwnerPresent(config.webui.port))) {
+              await playbackEngine.quitMpv();
+              logger.info('MCP exit: no web server owns mpv — quit it');
+            }
+          } catch (err) {
+            logger.debug('shutdown cleanup error (continuing to exit):', err);
+          } finally {
+            process.exit(128 + signo);
+          }
+        })();
+      };
+      process.once('SIGINT', shutdown(2));
+      process.once('SIGTERM', shutdown(15));
     }
   } catch (error) {
     // Provide detailed error information for debugging

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,9 +202,24 @@ async function main(): Promise<void> {
     // (one MCP Server per session); stdio serves the single local-process client
     // the same way it always has.
     if (config.transport.type === 'http') {
+      // Loud warning for the genuinely unsafe combination: bound to a
+      // non-loopback address with no bearer token. We don't refuse to start —
+      // a NetworkPolicy-locked / same-pod deployment is a legitimate no-token
+      // case — but it must never happen silently.
+      const loopback = new Set(['127.0.0.1', '::1', 'localhost']);
+      if (!loopback.has(config.transport.host) && config.transport.authToken === undefined) {
+        logger.warn(
+          `MCP HTTP transport is bound to ${config.transport.host} with NO auth token — ` +
+          'anyone who can reach the port gets full, unauthenticated control of your Navidrome ' +
+          'library. Set transport.authToken, or restrict access with a network policy / ' +
+          'authenticating reverse proxy.'
+        );
+      }
+
       const http = await startHttpTransport({
         host: config.transport.host,
         port: config.transport.port,
+        authToken: config.transport.authToken,
         createMcpServer: () => createConfiguredServer(client, config),
       });
 

--- a/src/tools/handlers/registry.ts
+++ b/src/tools/handlers/registry.ts
@@ -23,6 +23,7 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprot
 import type { NavidromeClient } from '../../client/navidrome-client.js';
 import type { Config } from '../../config.js';
 import { ErrorFormatter } from '../../utils/error-formatter.js';
+import { logger } from '../../utils/logger.js';
 
 // Tool category interfaces
 export interface ToolCategory {
@@ -46,12 +47,21 @@ export class ToolRegistry {
   }
 
   async handleToolCall(name: string, args: unknown): Promise<unknown> {
+    const start = Date.now();
     for (const category of this.categories.values()) {
       const tool = category.tools.find(t => t.name === name);
       if (tool) {
-        return category.handleToolCall(name, args);
+        try {
+          const result = await category.handleToolCall(name, args);
+          logger.info(`tool ${name} ok (${Date.now() - start}ms)`);
+          return result;
+        } catch (err) {
+          logger.warn(`tool ${name} failed (${Date.now() - start}ms):`, err);
+          throw err;
+        }
       }
     }
+    logger.warn(`tool ${name} unknown`);
     throw new Error(ErrorFormatter.toolUnknown(name));
   }
 }

--- a/src/tools/handlers/registry.ts
+++ b/src/tools/handlers/registry.ts
@@ -53,7 +53,7 @@ export class ToolRegistry {
       if (tool) {
         try {
           const result = await category.handleToolCall(name, args);
-          logger.info(`tool ${name} ok (${Date.now() - start}ms)`);
+          logger.debug(`tool ${name} ok (${Date.now() - start}ms)`);
           return result;
         } catch (err) {
           logger.warn(`tool ${name} failed (${Date.now() - start}ms):`, err);

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -27,6 +27,9 @@ import { logger } from '../utils/logger.js';
 /** The single HTTP path the MCP Streamable HTTP transport is served on. */
 const MCP_PATH = '/mcp';
 
+/** Unauthenticated liveness endpoint for container/orchestrator health checks. */
+const HEALTH_PATH = '/healthz';
+
 /** A running HTTP transport: where clients connect, and how to stop it. */
 export interface HttpTransport {
   url: string;
@@ -76,9 +79,21 @@ export async function startHttpTransport(options: HttpTransportOptions): Promise
   });
 
   async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    // Only `/mcp` is served; query strings are ignored. `req.url` is always a
-    // path here (origin-form), so a prefix check on the pathname is sufficient.
+    // `/mcp` is the protocol endpoint; query strings are ignored. `req.url` is
+    // always a path here (origin-form), so a prefix check on the pathname is
+    // sufficient.
     const path = (req.url ?? '/').split('?')[0];
+
+    if (path === HEALTH_PATH) {
+      if (req.method === 'GET' || req.method === 'HEAD') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(req.method === 'HEAD' ? undefined : JSON.stringify({ status: 'ok' }));
+      } else {
+        writeError(res, 405, 'Method Not Allowed');
+      }
+      return;
+    }
+
     if (path !== MCP_PATH) {
       writeError(res, 404, `Not found. The MCP endpoint is ${MCP_PATH}.`);
       return;

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -132,7 +132,9 @@ export async function startHttpTransport(options: HttpTransportOptions): Promise
     const startedAt = Date.now();
     res.once('finish', () => {
       const sid = headerValue(req, 'mcp-session-id');
-      const session = sid !== undefined ? ` [session ${sid}]` : '';
+      // Log a short fingerprint, never the raw id: with no other auth the
+      // session id IS the access token, so it must not land in INFO logs.
+      const session = sid !== undefined ? ` [session ${sessionFingerprint(sid)}]` : '';
       const elapsed = Date.now() - startedAt;
       logger.info(`HTTP ${method} ${path} -> ${String(res.statusCode)} (${String(elapsed)}ms)${session}`);
     });
@@ -289,6 +291,15 @@ function isAuthorized(req: IncomingMessage, token: string): boolean {
   const a = createHash('sha256').update(presented).digest();
   const b = createHash('sha256').update(token).digest();
   return timingSafeEqual(a, b);
+}
+
+/**
+ * A short, non-reversible fingerprint of a session id for logs — the first 8 hex
+ * of its sha256. Enough to correlate a session's requests without writing the
+ * (auth-equivalent) id itself to the log stream.
+ */
+function sessionFingerprint(sessionId: string): string {
+  return createHash('sha256').update(sessionId).digest('hex').slice(0, 8);
 }
 
 /** Read a single header value as a string (collapsing the array form). */

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -17,7 +17,7 @@
  */
 
 import { createServer, type Server as HttpServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
@@ -39,6 +39,14 @@ export interface HttpTransport {
 interface HttpTransportOptions {
   host: string;
   port: number;
+  /**
+   * Optional bearer token. When set, every `/mcp` request must carry
+   * `Authorization: Bearer <token>` (compared in constant time) or it is
+   * rejected with 401 before reaching the transport. Left undefined, the
+   * endpoint is unauthenticated — only safe on loopback or behind a network
+   * policy / authenticating proxy. `/healthz` is never gated.
+   */
+  authToken?: string | undefined;
   /**
    * Builds a fresh, fully-configured MCP {@link Server} for a new session. The
    * Streamable HTTP transport is stateful — one transport (and one Server) per
@@ -62,12 +70,12 @@ interface HttpTransportOptions {
  *     session's transport (GET opens the SSE stream, DELETE terminates it).
  *   - Anything else → a JSON-RPC / HTTP error, leaving no orphaned session.
  *
- * Binding host comes from config (`0.0.0.0` by default for this transport, since
- * choosing HTTP is the opt-in to network exposure). There is no built-in auth —
- * front it with a reverse proxy / network policy.
+ * Binding host comes from config (loopback by default; `expose`/an explicit
+ * host opt into network exposure). An optional bearer `authToken` gates every
+ * `/mcp` request; without one, front it with a reverse proxy / network policy.
  */
 export async function startHttpTransport(options: HttpTransportOptions): Promise<HttpTransport> {
-  const { host, port, createMcpServer } = options;
+  const { host, port, authToken, createMcpServer } = options;
 
   // Active sessions keyed by the SDK-generated session id. A transport removes
   // itself here on close (DELETE, client disconnect, or transport error) so the
@@ -105,6 +113,14 @@ export async function startHttpTransport(options: HttpTransportOptions): Promise
 
     if (path !== MCP_PATH) {
       writeError(res, 404, `Not found. The MCP endpoint is ${MCP_PATH}.`);
+      return;
+    }
+
+    // Bearer gate (when configured): the session id is the only other access
+    // control, so a missing/wrong token is rejected before we touch a session.
+    if (authToken !== undefined && !isAuthorized(req, authToken)) {
+      res.writeHead(401, { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer' });
+      res.end(JSON.stringify({ error: 'Unauthorized' }));
       return;
     }
 
@@ -214,6 +230,22 @@ export async function startHttpTransport(options: HttpTransportOptions): Promise
   const displayHost = host === '0.0.0.0' || host === '::' ? 'localhost' : host;
   const url = `http://${displayHost}:${String(boundPort)}${MCP_PATH}`;
   return { url, close };
+}
+
+/**
+ * Constant-time bearer check. Hashes both sides to a fixed-width digest first so
+ * `timingSafeEqual` (which throws on length mismatch) is safe and the comparison
+ * leaks neither the token length nor where it first differs.
+ */
+function isAuthorized(req: IncomingMessage, token: string): boolean {
+  const header = headerValue(req, 'authorization');
+  if (header === undefined) return false;
+  const match = /^Bearer[ ]+(.+)$/i.exec(header.trim());
+  const presented = match?.[1];
+  if (presented === undefined) return false;
+  const a = createHash('sha256').update(presented).digest();
+  const b = createHash('sha256').update(token).digest();
+  return timingSafeEqual(a, b);
 }
 
 /** Read a single header value as a string (collapsing the array form). */

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -82,6 +82,7 @@ export async function startHttpTransport(options: HttpTransportOptions): Promise
     // `/mcp` is the protocol endpoint; query strings are ignored. `req.url` is
     // always a path here (origin-form), so a prefix check on the pathname is
     // sufficient.
+    const method = req.method ?? 'GET';
     const path = (req.url ?? '/').split('?')[0];
 
     if (path === HEALTH_PATH) {
@@ -93,6 +94,14 @@ export async function startHttpTransport(options: HttpTransportOptions): Promise
       }
       return;
     }
+
+    const startedAt = Date.now();
+    res.once('finish', () => {
+      const sid = headerValue(req, 'mcp-session-id');
+      const session = sid !== undefined ? ` [session ${sid}]` : '';
+      const elapsed = Date.now() - startedAt;
+      logger.info(`HTTP ${method} ${path} -> ${String(res.statusCode)} (${String(elapsed)}ms)${session}`);
+    });
 
     if (path !== MCP_PATH) {
       writeError(res, 404, `Not found. The MCP endpoint is ${MCP_PATH}.`);

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -30,6 +30,14 @@ const MCP_PATH = '/mcp';
 /** Unauthenticated liveness endpoint for container/orchestrator health checks. */
 const HEALTH_PATH = '/healthz';
 
+/**
+ * Body cap for the MCP endpoint. Generous compared with the web UI's 16 KB
+ * control routes — a real tool call (e.g. `add_tracks_to_playlist` with many
+ * ids) can be sizeable — but still bounded so a client can't make us buffer
+ * arbitrary input. Bodies over this are rejected with 400.
+ */
+const MCP_MAX_BODY_BYTES = 4 * 1024 * 1024;
+
 /** A running HTTP transport: where clients connect, and how to stop it. */
 export interface HttpTransport {
   url: string;
@@ -166,7 +174,7 @@ export async function startHttpTransport(options: HttpTransportOptions): Promise
     // pre-parsed body as the third arg, so it does not re-read the stream.
     let body: unknown;
     try {
-      body = await readJsonBody(req);
+      body = await readJsonBody(req, MCP_MAX_BODY_BYTES);
     } catch {
       writeError(res, 400, 'Invalid or oversized request body');
       return;

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -48,6 +48,19 @@ interface HttpTransportOptions {
    */
   authToken?: string | undefined;
   /**
+   * Extra `Host` header values to accept for DNS-rebinding protection, on top of
+   * the loopback + bound `host:port` set derived automatically. A deployment
+   * reached through a proxy / k8s Service must list the external `host:port`
+   * clients actually use (the protection matches the literal `Host` header).
+   */
+  allowedHosts?: string[] | undefined;
+  /**
+   * Allowed `Origin` header values (browser clients only). When set, requests
+   * with a missing or non-listed Origin are rejected; left unset, Origin is not
+   * checked (non-browser MCP clients send none).
+   */
+  allowedOrigins?: string[] | undefined;
+  /**
    * Builds a fresh, fully-configured MCP {@link Server} for a new session. The
    * Streamable HTTP transport is stateful — one transport (and one Server) per
    * client session — so this is invoked once per `initialize`, sharing the
@@ -75,7 +88,12 @@ interface HttpTransportOptions {
  * `/mcp` request; without one, front it with a reverse proxy / network policy.
  */
 export async function startHttpTransport(options: HttpTransportOptions): Promise<HttpTransport> {
-  const { host, port, authToken, createMcpServer } = options;
+  const { host, port, authToken, allowedOrigins, createMcpServer } = options;
+
+  // Computed after listen() (so the ephemeral `port: 0` case resolves to the
+  // real bound port) and read when each per-session transport is constructed —
+  // safe because requests only arrive after listen resolves.
+  let allowedHosts: string[] = [];
 
   // Active sessions keyed by the SDK-generated session id. A transport removes
   // itself here on close (DELETE, client disconnect, or transport error) so the
@@ -172,6 +190,12 @@ export async function startHttpTransport(options: HttpTransportOptions): Promise
 
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: (): string => randomUUID(),
+      // DNS-rebinding protection: reject requests whose Host (and, if configured,
+      // Origin) header isn't allow-listed, blocking a malicious web page from
+      // driving this server through the victim's browser even on loopback.
+      enableDnsRebindingProtection: true,
+      allowedHosts,
+      ...(allowedOrigins !== undefined ? { allowedOrigins } : {}),
       onsessioninitialized: (sid): void => {
         transports.set(sid, transport);
         logger.debug(`MCP HTTP session initialized: ${sid}`);
@@ -227,6 +251,17 @@ export async function startHttpTransport(options: HttpTransportOptions): Promise
   // tests). Report a loopback-friendly host when bound to a wildcard address.
   const address = httpServer.address();
   const boundPort = typeof address === 'object' && address !== null ? address.port : port;
+
+  // Allow-list the bound host:port plus the loopback aliases a local client may
+  // send, then add any operator-configured externals (proxy / Service names).
+  const portStr = String(boundPort);
+  allowedHosts = [
+    ...new Set([
+      ...[host, '127.0.0.1', 'localhost', '[::1]'].map((h) => `${h}:${portStr}`),
+      ...(options.allowedHosts ?? []),
+    ]),
+  ];
+
   const displayHost = host === '0.0.0.0' || host === '::' ? 'localhost' : host;
   const url = `http://${displayHost}:${String(boundPort)}${MCP_PATH}`;
   return { url, close };

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -1,0 +1,212 @@
+/**
+ * Navidrome MCP Server - Streamable HTTP transport
+ * Copyright (C) 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { createServer, type Server as HttpServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { writeError, readJsonBody } from '../webui/http-helpers.js';
+import { logger } from '../utils/logger.js';
+
+/** The single HTTP path the MCP Streamable HTTP transport is served on. */
+const MCP_PATH = '/mcp';
+
+/** A running HTTP transport: where clients connect, and how to stop it. */
+export interface HttpTransport {
+  url: string;
+  close: () => Promise<void>;
+}
+
+interface HttpTransportOptions {
+  host: string;
+  port: number;
+  /**
+   * Builds a fresh, fully-configured MCP {@link Server} for a new session. The
+   * Streamable HTTP transport is stateful — one transport (and one Server) per
+   * client session — so this is invoked once per `initialize`, sharing the
+   * already-authenticated Navidrome client captured in the closure.
+   */
+  createMcpServer: () => Server;
+}
+
+/**
+ * Start the MCP server over the Streamable HTTP transport (MCP spec
+ * 2025-03-26). Unlike stdio, this binds a TCP socket so a long-lived process
+ * (e.g. a container alongside Navidrome in a cluster) can serve remote MCP
+ * clients directly — no `supergateway`/`mcp-proxy` bridge required.
+ *
+ * Stateful session model (the SDK's recommended pattern):
+ *   - POST `/mcp` with an `initialize` request and NO session id → a new
+ *     transport + Server are created and the response carries an
+ *     `Mcp-Session-Id` header the client echoes on every later request.
+ *   - POST/GET/DELETE `/mcp` with a known `Mcp-Session-Id` → routed to that
+ *     session's transport (GET opens the SSE stream, DELETE terminates it).
+ *   - Anything else → a JSON-RPC / HTTP error, leaving no orphaned session.
+ *
+ * Binding host comes from config (`0.0.0.0` by default for this transport, since
+ * choosing HTTP is the opt-in to network exposure). There is no built-in auth —
+ * front it with a reverse proxy / network policy.
+ */
+export async function startHttpTransport(options: HttpTransportOptions): Promise<HttpTransport> {
+  const { host, port, createMcpServer } = options;
+
+  // Active sessions keyed by the SDK-generated session id. A transport removes
+  // itself here on close (DELETE, client disconnect, or transport error) so the
+  // map never leaks across reconnects.
+  const transports = new Map<string, StreamableHTTPServerTransport>();
+
+  const httpServer: HttpServer = createServer((req, res) => {
+    void handleRequest(req, res);
+  });
+
+  async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // Only `/mcp` is served; query strings are ignored. `req.url` is always a
+    // path here (origin-form), so a prefix check on the pathname is sufficient.
+    const path = (req.url ?? '/').split('?')[0];
+    if (path !== MCP_PATH) {
+      writeError(res, 404, `Not found. The MCP endpoint is ${MCP_PATH}.`);
+      return;
+    }
+
+    try {
+      if (req.method === 'POST') {
+        await handlePost(req, res);
+      } else if (req.method === 'GET' || req.method === 'DELETE') {
+        await handleSessionRequest(req, res);
+      } else {
+        writeError(res, 405, 'Method Not Allowed');
+      }
+    } catch (err) {
+      logger.error('HTTP transport request failed:', err);
+      if (!res.headersSent) {
+        writeError(res, 500, 'Internal server error');
+      } else {
+        res.end();
+      }
+    }
+  }
+
+  async function handlePost(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // Read the body ourselves so we can route on it (decide new-session vs.
+    // existing-session) before handing it to the transport. The SDK accepts a
+    // pre-parsed body as the third arg, so it does not re-read the stream.
+    let body: unknown;
+    try {
+      body = await readJsonBody(req);
+    } catch {
+      writeError(res, 400, 'Invalid or oversized request body');
+      return;
+    }
+
+    const sessionId = headerValue(req, 'mcp-session-id');
+    const existing = sessionId !== undefined ? transports.get(sessionId) : undefined;
+
+    if (existing !== undefined) {
+      await existing.handleRequest(req, res, body);
+      return;
+    }
+
+    // No live session: only an `initialize` request may open one. Anything else
+    // is a stale/unknown session id (or a non-init first message) and is
+    // rejected per the spec rather than silently spawning a session.
+    if (sessionId !== undefined || !isInitializeRequest(body)) {
+      writeJsonRpcError(res, 400, 'Bad Request: no valid session ID provided');
+      return;
+    }
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: (): string => randomUUID(),
+      onsessioninitialized: (sid): void => {
+        transports.set(sid, transport);
+        logger.debug(`MCP HTTP session initialized: ${sid}`);
+      },
+    });
+    // Drop the session from the map when the transport closes (DELETE or
+    // disconnect), so reconnecting clients don't accumulate dead entries.
+    transport.onclose = (): void => {
+      const sid = transport.sessionId;
+      if (sid !== undefined && transports.delete(sid)) {
+        logger.debug(`MCP HTTP session closed: ${sid}`);
+      }
+    };
+
+    const server = createMcpServer();
+    await server.connect(transport);
+    await transport.handleRequest(req, res, body);
+  }
+
+  async function handleSessionRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const sessionId = headerValue(req, 'mcp-session-id');
+    const transport = sessionId !== undefined ? transports.get(sessionId) : undefined;
+    if (transport === undefined) {
+      writeJsonRpcError(res, 400, 'Bad Request: no valid session ID provided');
+      return;
+    }
+    await transport.handleRequest(req, res);
+  }
+
+  await new Promise<void>((resolvePromise, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(port, host, () => {
+      httpServer.removeListener('error', reject);
+      resolvePromise();
+    });
+  });
+
+  const close = (): Promise<void> =>
+    new Promise<void>((resolvePromise) => {
+      // Close each transport so in-flight SSE streams end and sessions clear,
+      // then stop accepting connections. Terminate keep-alive sockets so
+      // server.close()'s callback actually fires.
+      for (const transport of transports.values()) {
+        void transport.close();
+      }
+      transports.clear();
+      httpServer.closeAllConnections();
+      httpServer.close(() => resolvePromise());
+    });
+
+  // Read the actually-bound port from the socket — it differs from the
+  // requested one when `port: 0` asks the OS for an ephemeral port (used by
+  // tests). Report a loopback-friendly host when bound to a wildcard address.
+  const address = httpServer.address();
+  const boundPort = typeof address === 'object' && address !== null ? address.port : port;
+  const displayHost = host === '0.0.0.0' || host === '::' ? 'localhost' : host;
+  const url = `http://${displayHost}:${String(boundPort)}${MCP_PATH}`;
+  return { url, close };
+}
+
+/** Read a single header value as a string (collapsing the array form). */
+function headerValue(req: IncomingMessage, name: string): string | undefined {
+  const raw = req.headers[name];
+  if (raw === undefined) return undefined;
+  return Array.isArray(raw) ? raw[0] : raw;
+}
+
+/** Emit a JSON-RPC error envelope (what MCP clients expect) with an HTTP code. */
+function writeJsonRpcError(res: ServerResponse, status: number, message: string): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      error: { code: -32_000, message },
+      id: null,
+    })
+  );
+}

--- a/src/webui/http-helpers.ts
+++ b/src/webui/http-helpers.ts
@@ -19,12 +19,13 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
 /**
- * Body-size cap for control-route JSON payloads. Our largest body is a seek
- * (`{seconds, mode}`) — well under a hundred bytes. Anything bigger is a
- * misconfigured client or a malicious one, and we'd rather fail fast than
- * buffer arbitrary input on a localhost-default server.
+ * Default body-size cap for control-route JSON payloads. Our largest web-UI body
+ * is a seek (`{seconds, mode}`) — well under a hundred bytes. Anything bigger is
+ * a misconfigured client or a malicious one, and we'd rather fail fast than
+ * buffer arbitrary input on a localhost-default server. Callers handling larger
+ * payloads (e.g. the MCP transport) pass a bigger, still-bounded cap.
  */
-const MAX_BODY_BYTES = 16 * 1024;
+const DEFAULT_MAX_BODY_BYTES = 16 * 1024;
 
 export function writeJson(res: ServerResponse, status: number, body: unknown): void {
   const payload = JSON.stringify(body);
@@ -58,10 +59,14 @@ export async function runAction(res: ServerResponse, action: () => Promise<unkno
 /**
  * Read a JSON request body with a hard size cap. Empty bodies resolve to
  * `null` so caller can distinguish "no body provided" from "{}" — useful for
- * routes that accept no input. Beyond `MAX_BODY_BYTES`, the connection is
- * destroyed (no partial JSON parse) and the promise rejects.
+ * routes that accept no input. Beyond `maxBytes` (defaults to
+ * `DEFAULT_MAX_BODY_BYTES`), the connection is destroyed (no partial JSON parse)
+ * and the promise rejects.
  */
-export async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+export async function readJsonBody(
+  req: IncomingMessage,
+  maxBytes: number = DEFAULT_MAX_BODY_BYTES,
+): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     let received = 0;
@@ -70,7 +75,7 @@ export async function readJsonBody(req: IncomingMessage): Promise<unknown> {
     req.on('data', (chunk: Buffer) => {
       if (aborted) return;
       received += chunk.length;
-      if (received > MAX_BODY_BYTES) {
+      if (received > maxBytes) {
         aborted = true;
         req.destroy();
         reject(new Error('Request body too large'));

--- a/tests/unit/config/config-resolve.test.ts
+++ b/tests/unit/config/config-resolve.test.ts
@@ -95,6 +95,31 @@ describe('config resolution', () => {
       expect((await loadConfig()).webui.host).toBe('127.0.0.1');
     });
 
+    it('defaults the transport to stdio on 0.0.0.0:3000 when unset', async () => {
+      write(BASE);
+      const c = await loadConfig();
+      expect(c.transport).toEqual({ type: 'stdio', host: '0.0.0.0', port: 3000 });
+    });
+
+    it('maps an explicit http transport block', async () => {
+      write({ ...BASE, transport: { type: 'http', host: '127.0.0.1', port: 9000 } });
+      const c = await loadConfig();
+      expect(c.transport).toEqual({ type: 'http', host: '127.0.0.1', port: 9000 });
+    });
+
+    it('falls back to 0.0.0.0 when transport host is blank', async () => {
+      write({ ...BASE, transport: { type: 'http', host: '   ' } });
+      const c = await loadConfig();
+      expect(c.transport.host).toBe('0.0.0.0');
+      expect(c.transport.port).toBe(3000);
+    });
+
+    it('rejects an unknown transport type', async () => {
+      write({ ...BASE, transport: { type: 'websocket' } });
+      // SettingsFileSchema rejects the bad enum → store reads as unconfigured.
+      expect(await resolveConfigState()).toEqual({ configured: false });
+    });
+
     it('requires BOTH provider and user agent to enable lyrics', async () => {
       write({ ...BASE, features: { lyricsProvider: 'lrclib' } });
       expect((await loadConfig()).features.lyrics).toBe(false);

--- a/tests/unit/config/config-resolve.test.ts
+++ b/tests/unit/config/config-resolve.test.ts
@@ -128,6 +128,13 @@ describe('config resolution', () => {
       expect((await loadConfig()).transport.host).toBe('1.2.3.4');
     });
 
+    it('maps a non-empty transport authToken through, blank → undefined', async () => {
+      write({ ...BASE, transport: { type: 'http', authToken: '  secret-token  ' } });
+      expect((await loadConfig()).transport.authToken).toBe('secret-token');
+      write({ ...BASE, transport: { type: 'http', authToken: '   ' } });
+      expect((await loadConfig()).transport.authToken).toBeUndefined();
+    });
+
     it('rejects an unknown transport type', async () => {
       write({ ...BASE, transport: { type: 'websocket' } });
       // SettingsFileSchema rejects the bad enum → store reads as unconfigured.

--- a/tests/unit/config/config-resolve.test.ts
+++ b/tests/unit/config/config-resolve.test.ts
@@ -95,23 +95,37 @@ describe('config resolution', () => {
       expect((await loadConfig()).webui.host).toBe('127.0.0.1');
     });
 
-    it('defaults the transport to stdio on 0.0.0.0:3000 when unset', async () => {
+    it('defaults the transport to stdio on loopback:3000 when unset', async () => {
       write(BASE);
       const c = await loadConfig();
-      expect(c.transport).toEqual({ type: 'stdio', host: '0.0.0.0', port: 3000 });
+      expect(c.transport).toEqual({ type: 'stdio', host: '127.0.0.1', port: 3000, expose: false });
     });
 
     it('maps an explicit http transport block', async () => {
-      write({ ...BASE, transport: { type: 'http', host: '127.0.0.1', port: 9000 } });
+      write({ ...BASE, transport: { type: 'http', host: '10.0.0.5', port: 9000 } });
       const c = await loadConfig();
-      expect(c.transport).toEqual({ type: 'http', host: '127.0.0.1', port: 9000 });
+      expect(c.transport).toEqual({ type: 'http', host: '10.0.0.5', port: 9000, expose: false });
     });
 
-    it('falls back to 0.0.0.0 when transport host is blank', async () => {
+    it('stays on loopback when host is blank and expose is unset', async () => {
       write({ ...BASE, transport: { type: 'http', host: '   ' } });
       const c = await loadConfig();
-      expect(c.transport.host).toBe('0.0.0.0');
+      expect(c.transport.host).toBe('127.0.0.1');
       expect(c.transport.port).toBe(3000);
+    });
+
+    it('flips the bind to 0.0.0.0 when expose is set and no explicit host', async () => {
+      write({ ...BASE, transport: { type: 'http', expose: true } });
+      const c = await loadConfig();
+      expect(c.transport.host).toBe('0.0.0.0');
+      expect(c.transport.expose).toBe(true);
+    });
+
+    it('lets an explicit transport host win over expose', async () => {
+      write({ ...BASE, transport: { type: 'http', expose: true, host: '127.0.0.1' } });
+      expect((await loadConfig()).transport.host).toBe('127.0.0.1');
+      write({ ...BASE, transport: { type: 'http', expose: false, host: '1.2.3.4' } });
+      expect((await loadConfig()).transport.host).toBe('1.2.3.4');
     });
 
     it('rejects an unknown transport type', async () => {

--- a/tests/unit/config/seed.test.ts
+++ b/tests/unit/config/seed.test.ts
@@ -18,7 +18,7 @@ const ENV_KEYS = [
   'WEBUI_PORT', 'WEBUI_EXPOSE', 'DEBUG', 'LASTFM_API_KEY',
   'RADIO_BROWSER_USER_AGENT', 'RADIO_BROWSER_BASE',
   'LYRICS_PROVIDER', 'LRCLIB_USER_AGENT', 'LRCLIB_BASE',
-  'MCP_TRANSPORT', 'MCP_HTTP_HOST', 'MCP_HTTP_PORT',
+  'MCP_TRANSPORT', 'MCP_HTTP_HOST', 'MCP_HTTP_PORT', 'MCP_HTTP_EXPOSE',
 ];
 
 describe('buildFormSeed', () => {
@@ -82,23 +82,26 @@ describe('buildFormSeed', () => {
     expect(seed.features?.lrclibBase).toBe('https://lrclib.example');
   });
 
-  it('defaults the transport to stdio when no env is set', () => {
+  it('defaults the transport to stdio (unexposed) when no env is set', () => {
     process.env['NAVIDROME_URL'] = 'http://env:4533';
     const seed = buildFormSeed();
     expect(seed.transport?.type).toBe('stdio');
     expect(seed.transport?.port).toBe(3000);
     expect(seed.transport?.host ?? null).toBeNull();
+    expect(seed.transport?.expose).toBe(false);
   });
 
   it('imports the http transport from env vars', () => {
     process.env['NAVIDROME_URL'] = 'http://env:4533';
     process.env['MCP_TRANSPORT'] = 'http';
-    process.env['MCP_HTTP_HOST'] = '0.0.0.0';
+    process.env['MCP_HTTP_HOST'] = '10.0.0.5';
     process.env['MCP_HTTP_PORT'] = '8080';
+    process.env['MCP_HTTP_EXPOSE'] = 'true';
     const seed = buildFormSeed();
     expect(seed.transport?.type).toBe('http');
-    expect(seed.transport?.host).toBe('0.0.0.0');
+    expect(seed.transport?.host).toBe('10.0.0.5');
     expect(seed.transport?.port).toBe(8080);
+    expect(seed.transport?.expose).toBe(true);
   });
 
   it('ignores an unrecognized MCP_TRANSPORT value (falls back to stdio)', () => {

--- a/tests/unit/config/seed.test.ts
+++ b/tests/unit/config/seed.test.ts
@@ -19,6 +19,7 @@ const ENV_KEYS = [
   'RADIO_BROWSER_USER_AGENT', 'RADIO_BROWSER_BASE',
   'LYRICS_PROVIDER', 'LRCLIB_USER_AGENT', 'LRCLIB_BASE',
   'MCP_TRANSPORT', 'MCP_HTTP_HOST', 'MCP_HTTP_PORT', 'MCP_HTTP_EXPOSE',
+  'MCP_HTTP_AUTH_TOKEN',
 ];
 
 describe('buildFormSeed', () => {
@@ -97,11 +98,13 @@ describe('buildFormSeed', () => {
     process.env['MCP_HTTP_HOST'] = '10.0.0.5';
     process.env['MCP_HTTP_PORT'] = '8080';
     process.env['MCP_HTTP_EXPOSE'] = 'true';
+    process.env['MCP_HTTP_AUTH_TOKEN'] = 'tok-123';
     const seed = buildFormSeed();
     expect(seed.transport?.type).toBe('http');
     expect(seed.transport?.host).toBe('10.0.0.5');
     expect(seed.transport?.port).toBe(8080);
     expect(seed.transport?.expose).toBe(true);
+    expect(seed.transport?.authToken).toBe('tok-123');
   });
 
   it('ignores an unrecognized MCP_TRANSPORT value (falls back to stdio)', () => {

--- a/tests/unit/config/seed.test.ts
+++ b/tests/unit/config/seed.test.ts
@@ -18,6 +18,7 @@ const ENV_KEYS = [
   'WEBUI_PORT', 'WEBUI_EXPOSE', 'DEBUG', 'LASTFM_API_KEY',
   'RADIO_BROWSER_USER_AGENT', 'RADIO_BROWSER_BASE',
   'LYRICS_PROVIDER', 'LRCLIB_USER_AGENT', 'LRCLIB_BASE',
+  'MCP_TRANSPORT', 'MCP_HTTP_HOST', 'MCP_HTTP_PORT',
 ];
 
 describe('buildFormSeed', () => {
@@ -79,6 +80,31 @@ describe('buildFormSeed', () => {
     const seed = buildFormSeed();
     expect(seed.features?.radioBrowserUserAgent).toBe('MyAgent');
     expect(seed.features?.lrclibBase).toBe('https://lrclib.example');
+  });
+
+  it('defaults the transport to stdio when no env is set', () => {
+    process.env['NAVIDROME_URL'] = 'http://env:4533';
+    const seed = buildFormSeed();
+    expect(seed.transport?.type).toBe('stdio');
+    expect(seed.transport?.port).toBe(3000);
+    expect(seed.transport?.host ?? null).toBeNull();
+  });
+
+  it('imports the http transport from env vars', () => {
+    process.env['NAVIDROME_URL'] = 'http://env:4533';
+    process.env['MCP_TRANSPORT'] = 'http';
+    process.env['MCP_HTTP_HOST'] = '0.0.0.0';
+    process.env['MCP_HTTP_PORT'] = '8080';
+    const seed = buildFormSeed();
+    expect(seed.transport?.type).toBe('http');
+    expect(seed.transport?.host).toBe('0.0.0.0');
+    expect(seed.transport?.port).toBe(8080);
+  });
+
+  it('ignores an unrecognized MCP_TRANSPORT value (falls back to stdio)', () => {
+    process.env['NAVIDROME_URL'] = 'http://env:4533';
+    process.env['MCP_TRANSPORT'] = 'bogus';
+    expect(buildFormSeed().transport?.type).toBe('stdio');
   });
 
   it('coerces typed env vars (port int, expose/debug bool)', () => {

--- a/tests/unit/transport/http-transport.test.ts
+++ b/tests/unit/transport/http-transport.test.ts
@@ -15,6 +15,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import { request as httpRequest } from 'node:http';
 import { startHttpTransport, type HttpTransport } from '../../../src/transport/http.js';
 
 /**
@@ -48,6 +49,43 @@ function makeServer(): Server {
 /** Parse `http://host:port/mcp` back into a URL for the client transport. */
 function endpoint(handle: HttpTransport): URL {
   return new URL(handle.url);
+}
+
+/**
+ * POST an MCP `initialize` to `/mcp` with an explicit `Host` header — `fetch`
+ * forbids overriding Host, so we go through the low-level http client to exercise
+ * DNS-rebinding protection. Resolves with the response status.
+ */
+function postInitWithHost(handle: HttpTransport, hostHeader: string): Promise<number> {
+  const url = endpoint(handle);
+  const body = JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'c', version: '0' } },
+  });
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      {
+        hostname: url.hostname,
+        port: Number(url.port),
+        path: '/mcp',
+        method: 'POST',
+        headers: {
+          Host: hostHeader,
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        res.resume();
+        res.on('end', () => resolve(res.statusCode ?? 0));
+      },
+    );
+    req.on('error', reject);
+    req.end(body);
+  });
 }
 
 describe('Streamable HTTP transport', () => {
@@ -145,6 +183,49 @@ describe('Streamable HTTP transport', () => {
     const base = endpoint(handle);
     const res = await fetch(`http://${base.host}/healthz`, { method: 'POST' });
     expect(res.status).toBe(405);
+  });
+});
+
+describe('Streamable HTTP transport — DNS-rebinding protection', () => {
+  it('rejects a request with a foreign Host header (403)', async () => {
+    const handle = await startHttpTransport({
+      host: '127.0.0.1',
+      port: 0,
+      createMcpServer: () => makeServer(),
+    });
+    try {
+      expect(await postInitWithHost(handle, 'evil.example.com:1234')).toBe(403);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('accepts the bound loopback host automatically', async () => {
+    const handle = await startHttpTransport({
+      host: '127.0.0.1',
+      port: 0,
+      createMcpServer: () => makeServer(),
+    });
+    try {
+      const port = endpoint(handle).port;
+      expect(await postInitWithHost(handle, `127.0.0.1:${port}`)).toBe(200);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('accepts an operator-configured external host', async () => {
+    const handle = await startHttpTransport({
+      host: '127.0.0.1',
+      port: 0,
+      allowedHosts: ['mcp.example.com:8080'],
+      createMcpServer: () => makeServer(),
+    });
+    try {
+      expect(await postInitWithHost(handle, 'mcp.example.com:8080')).toBe(200);
+    } finally {
+      await handle.close();
+    }
   });
 });
 

--- a/tests/unit/transport/http-transport.test.ts
+++ b/tests/unit/transport/http-transport.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the Streamable HTTP transport.
+ *
+ * Spins up the real `startHttpTransport` server on an ephemeral loopback port,
+ * then drives it with the official MCP SDK client over Streamable HTTP so we
+ * exercise the genuine session handshake, tool invocation, routing, and
+ * teardown — not a mock of any of them. No mpv or Navidrome needed.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { startHttpTransport, type HttpTransport } from '../../../src/transport/http.js';
+
+/**
+ * Build a tiny MCP server exposing a single `ping` tool, fresh per session.
+ * Uses the low-level `Server` + manual JSON-schema handlers exactly like the
+ * real app's `registerTools` does — deliberately avoiding the high-level
+ * `McpServer` zod integration, which is incompatible with this project's Zod 4.
+ */
+function makeServer(): Server {
+  const server = new Server({ name: 'test', version: '0.0.0' }, { capabilities: { tools: {} } });
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: [
+      {
+        name: 'ping',
+        description: 'returns pong',
+        inputSchema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+        },
+      },
+    ],
+  }));
+  server.setRequestHandler(CallToolRequestSchema, (request) => {
+    const name = String((request.params.arguments as { name?: unknown }).name);
+    return { content: [{ type: 'text', text: `pong:${name}` }] };
+  });
+  return server;
+}
+
+/** Parse `http://host:port/mcp` back into a URL for the client transport. */
+function endpoint(handle: HttpTransport): URL {
+  return new URL(handle.url);
+}
+
+describe('Streamable HTTP transport', () => {
+  let handle: HttpTransport;
+
+  beforeEach(async () => {
+    handle = await startHttpTransport({
+      host: '127.0.0.1',
+      // Port 0 → OS assigns a free ephemeral port, avoiding collisions.
+      port: 0,
+      createMcpServer: () => makeServer(),
+    });
+  });
+
+  afterEach(async () => {
+    await handle.close();
+  });
+
+  it('reports a loopback URL on the /mcp path', () => {
+    const url = endpoint(handle);
+    expect(url.pathname).toBe('/mcp');
+    expect(url.hostname).toBe('127.0.0.1');
+    expect(Number(url.port)).toBeGreaterThan(0);
+  });
+
+  it('completes the initialize handshake and lists tools', async () => {
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    await client.connect(new StreamableHTTPClientTransport(endpoint(handle)));
+    try {
+      const tools = await client.listTools();
+      expect(tools.tools.map((t) => t.name)).toContain('ping');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('routes a tool call through the established session', async () => {
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    await client.connect(new StreamableHTTPClientTransport(endpoint(handle)));
+    try {
+      const result = await client.callTool({ name: 'ping', arguments: { name: 'world' } });
+      expect(result.content).toEqual([{ type: 'text', text: 'pong:world' }]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('isolates concurrent clients into separate sessions', async () => {
+    const a = new Client({ name: 'a', version: '0.0.0' });
+    const b = new Client({ name: 'b', version: '0.0.0' });
+    await a.connect(new StreamableHTTPClientTransport(endpoint(handle)));
+    await b.connect(new StreamableHTTPClientTransport(endpoint(handle)));
+    try {
+      const [ra, rb] = await Promise.all([
+        a.callTool({ name: 'ping', arguments: { name: 'a' } }),
+        b.callTool({ name: 'ping', arguments: { name: 'b' } }),
+      ]);
+      expect(ra.content).toEqual([{ type: 'text', text: 'pong:a' }]);
+      expect(rb.content).toEqual([{ type: 'text', text: 'pong:b' }]);
+    } finally {
+      await a.close();
+      await b.close();
+    }
+  });
+
+  it('rejects a POST with an unknown session id', async () => {
+    const res = await fetch(handle.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        'mcp-session-id': 'does-not-exist',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error?: { message?: string } };
+    expect(json.error?.message).toMatch(/session/i);
+  });
+
+  it('404s on a non-MCP path', async () => {
+    const base = endpoint(handle);
+    const res = await fetch(`http://${base.host}/nope`, { method: 'GET' });
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/transport/http-transport.test.ts
+++ b/tests/unit/transport/http-transport.test.ts
@@ -133,4 +133,17 @@ describe('Streamable HTTP transport', () => {
     const res = await fetch(`http://${base.host}/nope`, { method: 'GET' });
     expect(res.status).toBe(404);
   });
+
+  it('serves a 200 health check at /healthz', async () => {
+    const base = endpoint(handle);
+    const res = await fetch(`http://${base.host}/healthz`, { method: 'GET' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'ok' });
+  });
+
+  it('rejects a non-GET method on /healthz', async () => {
+    const base = endpoint(handle);
+    const res = await fetch(`http://${base.host}/healthz`, { method: 'POST' });
+    expect(res.status).toBe(405);
+  });
 });

--- a/tests/unit/transport/http-transport.test.ts
+++ b/tests/unit/transport/http-transport.test.ts
@@ -147,3 +147,69 @@ describe('Streamable HTTP transport', () => {
     expect(res.status).toBe(405);
   });
 });
+
+describe('Streamable HTTP transport — bearer auth', () => {
+  const TOKEN = 'super-secret-token';
+  let handle: HttpTransport;
+
+  beforeEach(async () => {
+    handle = await startHttpTransport({
+      host: '127.0.0.1',
+      port: 0,
+      authToken: TOKEN,
+      createMcpServer: () => makeServer(),
+    });
+  });
+
+  afterEach(async () => {
+    await handle.close();
+  });
+
+  const initBody = JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'c', version: '0' } },
+  });
+  const headers = (auth?: string): Record<string, string> => ({
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+    ...(auth !== undefined ? { Authorization: auth } : {}),
+  });
+
+  it('rejects a request with no Authorization header (401)', async () => {
+    const res = await fetch(handle.url, { method: 'POST', headers: headers(), body: initBody });
+    expect(res.status).toBe(401);
+    expect(res.headers.get('www-authenticate')).toMatch(/bearer/i);
+  });
+
+  it('rejects a wrong bearer token (401)', async () => {
+    const res = await fetch(handle.url, {
+      method: 'POST',
+      headers: headers('Bearer not-the-token'),
+      body: initBody,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts the correct bearer token and completes the handshake', async () => {
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    await client.connect(
+      new StreamableHTTPClientTransport(endpoint(handle), {
+        requestInit: { headers: { Authorization: `Bearer ${TOKEN}` } },
+      }),
+    );
+    try {
+      const tools = await client.listTools();
+      expect(tools.tools.map((t) => t.name)).toContain('ping');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('never gates /healthz behind the token', async () => {
+    const base = endpoint(handle);
+    const res = await fetch(`http://${base.host}/healthz`, { method: 'GET' });
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/unit/webui/http-helpers.test.ts
+++ b/tests/unit/webui/http-helpers.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for readJsonBody's size cap — in particular that the cap is
+ * parameterized, so the MCP transport can accept bodies larger than the web UI's
+ * tiny 16 KB control-route default while still bounding them.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage } from 'node:http';
+import { readJsonBody } from '../../../src/webui/http-helpers.js';
+
+/** Minimal IncomingMessage stand-in: emits the given chunks, then `end`. */
+function fakeReq(chunks: Buffer[]): IncomingMessage {
+  const emitter = new EventEmitter() as IncomingMessage & { destroy: () => void };
+  emitter.destroy = (): void => { emitter.emit('error', new Error('destroyed')); };
+  queueMicrotask(() => {
+    for (const c of chunks) emitter.emit('data', c);
+    emitter.emit('end');
+  });
+  return emitter;
+}
+
+const DEFAULT_CAP = 16 * 1024;
+
+describe('readJsonBody size cap', () => {
+  it('rejects a body over the default 16 KB cap', async () => {
+    const big = Buffer.from(JSON.stringify({ pad: 'x'.repeat(DEFAULT_CAP) }));
+    await expect(readJsonBody(fakeReq([big]))).rejects.toThrow();
+  });
+
+  it('accepts a >16 KB body when given a larger explicit cap', async () => {
+    const payload = { pad: 'x'.repeat(64 * 1024) };
+    const body = Buffer.from(JSON.stringify(payload));
+    expect(body.byteLength).toBeGreaterThan(DEFAULT_CAP);
+    await expect(readJsonBody(fakeReq([body]), 4 * 1024 * 1024)).resolves.toEqual(payload);
+  });
+
+  it('still rejects a body that exceeds the larger cap', async () => {
+    const body = Buffer.from('x'.repeat(2 * 1024));
+    await expect(readJsonBody(fakeReq([body]), 1024)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Fixes #29 

This PR adds:
- support for running this MCP server in streamable HTTP transport mode
- a Dockerfile to package the MCP server
- the GitHub Actions workflow to build and push the docker image to GHCR
- a little QoL around logging, especially useful when running as a standalone, long-lived server in cube

The use case for this is that I have navidrome deployed in my homelab k8s cluster and I also want the navidrome MCP deployed next to it.

I have built this image for testing in my fork and deployed it in my cluster. I linked it to Claude and can confirm it works. Here's what the logs would look like, for reference:

```bash
home-ops on  main took 20m51s
❯ k logs -n media navidrome-mcp-5877f46d6-p6d9l
[INFO] Navidrome client initialized
[INFO] LibraryManager initialized with 1 libraries, 1 active
[INFO] FilterCacheManager loaded 354 filter options across 6 types
[INFO] Navidrome MCP Server listening on http://localhost:3000/mcp (Streamable HTTP)
[INFO] HTTP POST /mcp -> 200 (8ms)
[INFO] HTTP POST /mcp -> 202 (1ms) [session 724cfb2f-8554-405d-80b3-46e2af6c726e]
[INFO] HTTP GET /mcp -> 200 (2ms) [session 724cfb2f-8554-405d-80b3-46e2af6c726e]
[INFO] HTTP DELETE /mcp -> 200 (0ms) [session 724cfb2f-8554-405d-80b3-46e2af6c726e]
[INFO] HTTP POST /mcp -> 200 (1ms)
[INFO] HTTP POST /mcp -> 202 (1ms) [session 1cbf36e1-d1b3-4fc4-95f6-4f85a6188499]
[INFO] HTTP POST /mcp -> 200 (2ms) [session 1cbf36e1-d1b3-4fc4-95f6-4f85a6188499]
[INFO] HTTP GET /mcp -> 200 (52ms) [session 1cbf36e1-d1b3-4fc4-95f6-4f85a6188499]
[INFO] HTTP DELETE /mcp -> 200 (1ms) [session 1cbf36e1-d1b3-4fc4-95f6-4f85a6188499]
[INFO] HTTP POST /mcp -> 200 (2ms)
[INFO] HTTP POST /mcp -> 202 (2ms) [session 3272cbe5-c21a-4427-a9eb-0e9f4a67cc35]
[INFO] HTTP GET /mcp -> 200 (3ms) [session 3272cbe5-c21a-4427-a9eb-0e9f4a67cc35]
[INFO] HTTP DELETE /mcp -> 200 (0ms) [session 3272cbe5-c21a-4427-a9eb-0e9f4a67cc35]
[INFO] HTTP POST /mcp -> 200 (2ms)
[INFO] HTTP POST /mcp -> 202 (1ms) [session 5d97757a-0849-47f5-8fd2-9a33092d94f8]
[INFO] tool test_connection ok (16ms)
[INFO] HTTP POST /mcp -> 200 (17ms) [session 5d97757a-0849-47f5-8fd2-9a33092d94f8]
[INFO] HTTP POST /mcp -> 200 (1ms) [session 5d97757a-0849-47f5-8fd2-9a33092d94f8]
[INFO] HTTP GET /mcp -> 200 (31ms) [session 5d97757a-0849-47f5-8fd2-9a33092d94f8]
[INFO] HTTP DELETE /mcp -> 200 (0ms) [session 5d97757a-0849-47f5-8fd2-9a33092d94f8]
[INFO] HTTP POST /mcp -> 200 (1ms)
[INFO] HTTP POST /mcp -> 202 (0ms) [session 4b81a5c7-3efe-4b57-b5f0-2d8c3ff1c50d]
[INFO] HTTP POST /mcp -> 200 (1ms) [session 4b81a5c7-3efe-4b57-b5f0-2d8c3ff1c50d]
[INFO] HTTP GET /mcp -> 200 (8ms) [session 4b81a5c7-3efe-4b57-b5f0-2d8c3ff1c50d]
[INFO] HTTP DELETE /mcp -> 200 (0ms) [session 4b81a5c7-3efe-4b57-b5f0-2d8c3ff1c50d]
[INFO] HTTP POST /mcp -> 200 (2ms)
[INFO] HTTP POST /mcp -> 202 (1ms) [session 5189b623-5595-4720-aee4-f8a3882e2258]
[INFO] HTTP DELETE /mcp -> 200 (0ms) [session 5189b623-5595-4720-aee4-f8a3882e2258]
[INFO] HTTP GET /mcp -> 400 (1ms) [session 5189b623-5595-4720-aee4-f8a3882e2258]
[INFO] HTTP POST /mcp -> 200 (0ms)
[INFO] HTTP POST /mcp -> 202 (1ms) [session 28557f73-d50a-4175-b046-e82132242f66]
[INFO] tool get_tag_distribution ok (6ms)
[INFO] HTTP POST /mcp -> 200 (6ms) [session 28557f73-d50a-4175-b046-e82132242f66]
[INFO] HTTP POST /mcp -> 200 (1ms) [session 28557f73-d50a-4175-b046-e82132242f66]
[INFO] HTTP GET /mcp -> 200 (18ms) [session 28557f73-d50a-4175-b046-e82132242f66]
[INFO] HTTP DELETE /mcp -> 200 (0ms) [session 28557f73-d50a-4175-b046-e82132242f66]
[INFO] HTTP POST /mcp -> 200 (1ms)
[INFO] HTTP POST /mcp -> 202 (1ms) [session d8da10ca-f48c-44e5-a988-4663ea79ae3b]
[INFO] HTTP POST /mcp -> 200 (1ms) [session d8da10ca-f48c-44e5-a988-4663ea79ae3b]
[INFO] HTTP GET /mcp -> 200 (9ms) [session d8da10ca-f48c-44e5-a988-4663ea79ae3b]
[INFO] HTTP DELETE /mcp -> 200 (1ms) [session d8da10ca-f48c-44e5-a988-4663ea79ae3b]
[INFO] HTTP POST /mcp -> 200 (2ms)
[INFO] HTTP POST /mcp -> 202 (2ms) [session 9cf668d6-4171-4141-928e-01a490feeaa2]
[INFO] HTTP GET /mcp -> 200 (0ms) [session 9cf668d6-4171-4141-928e-01a490feeaa2]
[INFO] HTTP DELETE /mcp -> 200 (0ms) [session 9cf668d6-4171-4141-928e-01a490feeaa2]
```