### PR TITLE
fix: anchor URL patterns in create_radio_station schema

### DIFF
--- a/src/tools/handlers/radio-handlers.ts
+++ b/src/tools/handlers/radio-handlers.ts
@@ -74,12 +74,12 @@ function getRadioTools(config: Config): Tool[] {
                 streamUrl: {
                   type: 'string',
                   description: 'Stream URL (required) - must be valid HTTP/HTTPS URL',
-                  pattern: '^https?://.+',
+                  pattern: '^https?://.+$',
                 },
                 homePageUrl: {
                   type: 'string',
                   description: 'Optional homepage URL for the station',
-                  pattern: '^https?://.+',
+                  pattern: '^https?://.+$',
                 },
               },
               required: ['name', 'streamUrl'],


### PR DESCRIPTION
The `streamUrl` and `homePageUrl` properties in `create_radio_station` declare `pattern: '^https?://.+'`.

That is valid JSON Schema — `pattern` is partial-match by default — but it breaks MCP clients that compile tool schemas into a constrained-decoding grammar for native function calling.

llama.cpp's `json-schema-to-grammar` converter requires patterns to be fully anchored, and rejects this one with:

```
JSON schema conversion failed: Pattern must start with '^' and end with '$'
```

The impact is broader than the one tool: the converter builds a single grammar for the entire tool set, so one unanchored pattern makes **every** tool exposed by this server unusable for tool calling, not just `create_radio_station`. I hit this running llama.cpp (Qwen2.5) behind Open WebUI — all 38 tools failed until this was fixed.

**The change is behaviourally equivalent.** `.+` is greedy and already matches to end of input, so every string accepted before is still accepted. The only additional inputs the anchored form rejects are ones containing newlines, since `.` excludes `\n` — and those are not valid URLs.

Verified against a live server: all 38 tools now compile cleanly, and `search_songs` routes correctly through native function calling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)